### PR TITLE
fix mobile keyword spacing and center clip tracker

### DIFF
--- a/src/components/ClipTrackerModal.tsx
+++ b/src/components/ClipTrackerModal.tsx
@@ -370,7 +370,7 @@ export default function ClipTrackerModal({
   }, [clipProgress]);
 
   return (
-    <div className="w-full -mb-4 sm:mb-2 pointer-events-auto">
+    <div className="w-full mb-2 pointer-events-auto">
       {/* Current Clip */}
       <div className="bg-black/80 backdrop-blur-lg border border-gray-800 rounded-lg shadow-white-glow">
       <button

--- a/src/components/SearchInterface.tsx
+++ b/src/components/SearchInterface.tsx
@@ -3788,18 +3788,14 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
             {searchMode === 'podcast-search' && (
               <div>
                 {resultViewStyle === SearchResultViewStyle.LIST && !isAnyModalOpen() && (
-                  <div className="flex gap-3">
-                    <div className="w-10 flex-shrink-0"></div>
-                    <div className="flex-1 min-w-0">
-                      <ClipTrackerModal
-                        clipProgress={clipProgress}
-                        isCollapsed={isClipTrackerCollapsed}
-                        onCollapsedChange={setIsClipTrackerCollapsed}
-                        auth={authConfig || undefined}
-                        onShareClick={handleClipShare}
-                      />
-                    </div>
-                    <div className="w-10 flex-shrink-0"></div>
+                  <div className="w-full">
+                    <ClipTrackerModal
+                      clipProgress={clipProgress}
+                      isCollapsed={isClipTrackerCollapsed}
+                      onCollapsedChange={setIsClipTrackerCollapsed}
+                      auth={authConfig || undefined}
+                      onShareClick={handleClipShare}
+                    />
                   </div>
                 )}
                 <form onSubmit={handleSearch}>
@@ -4472,20 +4468,16 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
               : null),
           }}
         >
-          <div className={`w-full flex flex-col ${isNarrowLayout ? 'max-w-[22rem]' : 'max-w-[40rem]'}`}>
+          <div className={`w-full flex flex-col ${isNarrowLayout ? '' : 'max-w-[40rem]'}`}>
             {resultViewStyle === SearchResultViewStyle.LIST && searchMode === 'podcast-search' && !isAnyModalOpen() && (
-              <div className="flex gap-3">
-                <div className="w-10 flex-shrink-0"></div>
-                <div className="flex-1 min-w-0">
-                  <ClipTrackerModal
-                    clipProgress={clipProgress}
-                    isCollapsed={isClipTrackerCollapsed}
-                    onCollapsedChange={setIsClipTrackerCollapsed}
-                    auth={authConfig || undefined}
-                    onShareClick={handleClipShare}
-                  />
-                </div>
-                <div className="w-10 flex-shrink-0"></div>
+              <div className="w-full">
+                <ClipTrackerModal
+                  clipProgress={clipProgress}
+                  isCollapsed={isClipTrackerCollapsed}
+                  onCollapsedChange={setIsClipTrackerCollapsed}
+                  auth={authConfig || undefined}
+                  onShareClick={handleClipShare}
+                />
               </div>
             )}
             {/* Result navigation strip — galaxy view, when a result is selected */}

--- a/src/components/SearchInterface.tsx
+++ b/src/components/SearchInterface.tsx
@@ -3789,7 +3789,8 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
               <div>
                 {resultViewStyle === SearchResultViewStyle.LIST && !isAnyModalOpen() && (
                   <div className="flex gap-3">
-                    <div className="flex-1">
+                    <div className="w-10 flex-shrink-0"></div>
+                    <div className="flex-1 min-w-0">
                       <ClipTrackerModal
                         clipProgress={clipProgress}
                         isCollapsed={isClipTrackerCollapsed}
@@ -3798,7 +3799,7 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
                         onShareClick={handleClipShare}
                       />
                     </div>
-                    <div className="w-10"></div>
+                    <div className="w-10 flex-shrink-0"></div>
                   </div>
                 )}
                 <form onSubmit={handleSearch}>
@@ -4474,7 +4475,8 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
           <div className={`w-full flex flex-col ${isNarrowLayout ? 'max-w-[22rem]' : 'max-w-[40rem]'}`}>
             {resultViewStyle === SearchResultViewStyle.LIST && searchMode === 'podcast-search' && !isAnyModalOpen() && (
               <div className="flex gap-3">
-                <div className="flex-1">
+                <div className="w-10 flex-shrink-0"></div>
+                <div className="flex-1 min-w-0">
                   <ClipTrackerModal
                     clipProgress={clipProgress}
                     isCollapsed={isClipTrackerCollapsed}
@@ -4483,7 +4485,7 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
                     onShareClick={handleClipShare}
                   />
                 </div>
-                <div className="w-10"></div>
+                <div className="w-10 flex-shrink-0"></div>
               </div>
             )}
             {/* Result navigation strip — galaxy view, when a result is selected */}
@@ -4508,7 +4510,7 @@ export default function SearchInterface({ isSharePage = false, isClipBatchPage =
             {/* Mobile keyword bar — sandwiched above the search input */}
             {isNarrowLayout && mobileKeywords.length > 0 && selectedParagraphId && (
               <div className="relative -mb-1.5" style={{ marginRight: '3rem' }}>
-                <div className="flex gap-1.5 overflow-x-auto scrollbar-hide pr-6">
+                <div className="flex gap-2.5 overflow-x-auto scrollbar-hide pr-6">
                   {mobileKeywords.map((kw, i) => (
                     <button
                       key={i}


### PR DESCRIPTION
## Summary

Two small mobile layout fixes in `SearchInterface.tsx`:

- **Keyword chips:** bumped the gap between mobile keyword chips from `gap-1.5` (6px) to `gap-2.5` (10px) so chips like `nicotine` / `addiction` / `replacement therapy` no longer look like they're touching.
- **ClipTrackerModal width / centering:** the tracker previously had only a `w-10` (40px) spacer on the right (to align it with the search input column), which made it visually off-center and squeezed its inner width — `No clips currently processing` was getting truncated to `No clips currentl…` on small viewports. Added a matching `w-10` spacer on the **left** for both the initial-search and floating-search-bar instances so the tracker is balanced/centered between equal margins. Also added `flex-shrink-0` on the spacers and `min-w-0` on the tracker column so flex sizing behaves correctly.

## Test plan

- [ ] On mobile (narrow layout), open the podcast-search initial state and confirm the clip tracker is horizontally centered and `No clips currently processing` is no longer truncated.
- [ ] After running a search, confirm the floating clip tracker above the search input is also centered.
- [ ] After a search with a selected paragraph, confirm the mobile keyword chips have visible breathing room between them and still scroll horizontally.
- [ ] Confirm desktop layout is unchanged.


Made with [Cursor](https://cursor.com)