### PR TITLE
tighten mobile result card and fix podcast seek race

### DIFF
--- a/src/components/podcast/PodcastSearchResultItem.tsx
+++ b/src/components/podcast/PodcastSearchResultItem.tsx
@@ -857,9 +857,20 @@ export const PodcastSearchResultItem = ({
               {/* Episode text */}
               <div className="flex-grow pr-0 sm:pr-4 min-w-0 w-full sm:max-w-[calc(100%-220px)]">
                 <h3 className="text-lg font-medium text-white line-clamp-1 sm:line-clamp-2">{episode}</h3>
-                <p className="text-sm text-gray-400 line-clamp-1">{creator}</p>
+                {/* Mobile: creator and date inline with bar separator to save vertical space */}
+                <p className="text-sm text-gray-400 line-clamp-1 sm:hidden">
+                  <span>{creator}</span>
+                  {date && (
+                    <>
+                      <span className="mx-1.5 text-gray-600">|</span>
+                      <span className="text-gray-500">{formatShortDate(date)}</span>
+                    </>
+                  )}
+                </p>
+                {/* Desktop: creator on its own line, date in its own calendar row */}
+                <p className="hidden sm:block text-sm text-gray-400 line-clamp-1">{creator}</p>
                 {date && (
-                  <div className="flex items-center gap-1 mt-1">
+                  <div className="hidden sm:flex items-center gap-1 mt-1">
                     <Calendar className="w-3 h-3 text-gray-500" />
                     <span className="text-xs text-gray-500">{formatShortDate(date)}</span>
                   </div>
@@ -867,16 +878,16 @@ export const PodcastSearchResultItem = ({
               </div>
   
               {/* Action Buttons */}
-              <div className={`mt-4 sm:mt-0 sm:w-[200px] sm:min-w-[200px] sm:flex-shrink-0 grid ${presentationContext === PresentationContext.clipBatch ? 'grid-cols-2 sm:grid-cols-2 grid-rows-2' : 'grid-rows-1 grid-flow-col sm:grid-cols-2 sm:grid-flow-row'} gap-2`}>
+              <div className={`mt-3 sm:mt-0 sm:w-[200px] sm:min-w-[200px] sm:flex-shrink-0 grid ${presentationContext === PresentationContext.clipBatch ? 'grid-cols-2 sm:grid-cols-2 grid-rows-2' : 'grid-rows-1 grid-flow-col sm:grid-cols-2 sm:grid-flow-row'} gap-1.5 sm:gap-2`}>
                 <button
-                  className="flex items-center justify-start px-2 py-2 rounded-md text-sm text-gray-300 hover:bg-gray-800 transition-colors"
+                  className="flex items-center justify-start px-1.5 py-1 sm:px-2 sm:py-2 rounded-md text-xs sm:text-sm text-gray-300 hover:bg-gray-800 transition-colors"
                   onClick={handleShare}
                 >
-                  <Link className="h-4 w-4 mr-2 flex-shrink-0" />
+                  <Link className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-2 flex-shrink-0" />
                   <span className="truncate">{showCopied ? 'Copied!' : 'Link'}</span>
                 </button>
                 <button
-                  className={`flex items-center justify-start px-2 py-2 rounded-md text-sm ${
+                  className={`flex items-center justify-start px-1.5 py-1 sm:px-2 sm:py-2 rounded-md text-xs sm:text-sm ${
                     listenLink
                       ? 'text-gray-300 hover:bg-gray-800 transition-colors'
                       : 'text-gray-600'
@@ -884,27 +895,27 @@ export const PodcastSearchResultItem = ({
                   onClick={handleListen}
                   disabled={!listenLink}
                 >
-                  <ExternalLink className="h-4 w-4 mr-2 flex-shrink-0" />
+                  <ExternalLink className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-2 flex-shrink-0" />
                   <span className="truncate">Listen</span>
                 </button>
                 {onClipProgress && (<button
-                  className="flex items-center justify-start px-2 py-2 rounded-md text-sm text-gray-300 hover:bg-gray-800 transition-colors"
+                  className="flex items-center justify-start px-1.5 py-1 sm:px-2 sm:py-2 rounded-md text-xs sm:text-sm text-gray-300 hover:bg-gray-800 transition-colors"
                   onClick={handleClip}
                 >
-                  <Scissors className="h-4 w-4 mr-2 flex-shrink-0" />
+                  <Scissors className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-2 flex-shrink-0" />
                   <span className="truncate">Clip</span>
                 </button>
                 )}
                 {presentationContext === PresentationContext.clipBatch && shareable && (
                   <button
-                    className="flex items-center justify-start px-2 py-2 rounded-md text-sm text-gray-300 hover:bg-gray-800 transition-colors"
+                    className="flex items-center justify-start px-1.5 py-1 sm:px-2 sm:py-2 rounded-md text-xs sm:text-sm text-gray-300 hover:bg-gray-800 transition-colors"
                     onClick={handleShareClip}
                     disabled={isShareProcessing}
                   >
                     {isShareProcessing ? (
-                      <Loader className="h-4 w-4 mr-2 flex-shrink-0 animate-spin" />
+                      <Loader className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-2 flex-shrink-0 animate-spin" />
                     ) : (
-                      <Share className="h-4 w-4 mr-2 flex-shrink-0" />
+                      <Share className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1 sm:mr-2 flex-shrink-0" />
                     )}
                     <span className="truncate">
                       {isShareProcessing ? '' : 'Share'}

--- a/src/context/AudioControllerContext.tsx
+++ b/src/context/AudioControllerContext.tsx
@@ -44,6 +44,10 @@ export const AudioControllerProvider: React.FC<{ children: React.ReactNode }> = 
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const pendingStartTimeRef = useRef<number | null>(null);
+  // Monotonic counter to bail out of stale playTrack invocations if a newer
+  // call supersedes them (e.g. user taps a second result while the first is
+  // still waiting for metadata to load).
+  const playSequenceRef = useRef(0);
 
   const loadTrack = useCallback((track: AudioTrack) => {
     const audio = audioRef.current;
@@ -91,10 +95,78 @@ export const AudioControllerProvider: React.FC<{ children: React.ReactNode }> = 
 
   const playTrack = useCallback(
     async (track: AudioTrack) => {
-      loadTrack(track);
-      await playInternal();
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      const sequence = ++playSequenceRef.current;
+
+      setCurrentTrack(track);
+      setIsPlaying(false);
+      setIsBuffering(true);
+
+      const desiredStart =
+        typeof track.startTime === 'number' ? track.startTime : null;
+      pendingStartTimeRef.current = desiredStart;
+
+      const isNewSrc = audio.src !== track.audioUrl;
+      if (isNewSrc) {
+        audio.src = track.audioUrl;
+        // Some mobile browsers won't begin loading until load() is called,
+        // which delays the loadedmetadata event we need before seeking.
+        try { audio.load(); } catch { /* ignore */ }
+      }
+
+      // Apply the seek BEFORE calling play() so playback always begins at the
+      // requested timestamp. Without this, on slow/mobile networks audio.play()
+      // resolves while readyState < HAVE_METADATA, so playback briefly starts
+      // at currentTime=0 (the start of the podcast) before loadedmetadata fires
+      // and the deferred seek snaps to the clip's start.
+      if (desiredStart !== null) {
+        if (audio.readyState < HTMLMediaElement.HAVE_METADATA) {
+          await new Promise<void>((resolve) => {
+            const cleanup = () => {
+              audio.removeEventListener('loadedmetadata', onLoaded);
+              audio.removeEventListener('error', onError);
+            };
+            const onLoaded = () => { cleanup(); resolve(); };
+            const onError = () => { cleanup(); resolve(); };
+            audio.addEventListener('loadedmetadata', onLoaded);
+            audio.addEventListener('error', onError);
+          });
+        }
+
+        // Bail out if a newer playTrack call superseded this one while we
+        // were awaiting metadata; otherwise we'd seek the wrong track.
+        if (sequence !== playSequenceRef.current) return;
+
+        try {
+          audio.currentTime = desiredStart;
+          setCurrentTime(desiredStart);
+        } catch {
+          // Ignore seek errors; the loadedmetadata handler still has the
+          // pendingStartTimeRef as a backup.
+        }
+        pendingStartTimeRef.current = null;
+      }
+
+      if (sequence !== playSequenceRef.current) return;
+
+      try {
+        await audio.play();
+        if (sequence !== playSequenceRef.current) return;
+        setIsPlaying(true);
+      } catch (err) {
+        console.error('Shared audio play error:', err);
+        if (sequence === playSequenceRef.current) {
+          setIsPlaying(false);
+        }
+      } finally {
+        if (sequence === playSequenceRef.current) {
+          setIsBuffering(false);
+        }
+      }
     },
-    [loadTrack, playInternal]
+    []
   );
 
   const togglePlay = useCallback(async () => {


### PR DESCRIPTION
## Summary

Two related mobile improvements bundled together.

### 1. `PodcastSearchResultItem` — denser mobile layout
- **Bar notation for date on mobile only:** the dedicated calendar/date row was costing a noticeable chunk of vertical real estate on small screens. On mobile we now render `Creator | 7/20/25` inline on a single line. Desktop is unchanged \u2014 it still gets the `Creator` line plus the calendar-icon + date row underneath.
- **Smaller horizontal action buttons on mobile:** the `Link` / `Listen` / `Clip` row was overflowing horizontally on narrow viewports. Tightened mobile-only padding (`px-1.5 py-1`), text size (`text-xs`), icon size (`h-3.5 w-3.5`), and inter-button gap (`gap-1.5`). Desktop sizing (`px-2 py-2`, `text-sm`, `h-4 w-4`, `gap-2`) is preserved via `sm:` variants.

### 2. `AudioControllerContext` \u2014 fix \"jumps to start of podcast\" seek race
On slow / mobile networks, tapping a result sometimes started playback at the very beginning of the podcast instead of the requested clip timestamp. Root cause: `playTrack` called `loadTrack(track)` (which set `audio.src` and queued the seek) then immediately called `audio.play()`. Setting `audio.src` resets `readyState` to `HAVE_NOTHING`, so the seek was deferred to the `loadedmetadata` event \u2014 but `audio.play()` could resolve and start producing audio at `currentTime = 0` before that event fired.

Fix: refactor `playTrack` to **await `loadedmetadata` and apply the seek before calling `play()`**. Also added:
- An explicit `audio.load()` after `audio.src = ...` so mobile browsers begin loading immediately.
- A monotonic `playSequenceRef` counter so a second rapid tap supersedes a still-pending first call instead of seeking the now-wrong track.
- The existing `loadedmetadata` handler is kept as a backup path (covers external `loadTrack` callers).

## Test plan

- [ ] On mobile, search and confirm each result card now shows `Creator | date` on a single line and the action button row fits comfortably without horizontal overflow.
- [ ] On desktop, confirm the result card layout is visually unchanged (separate creator line + calendar/date row, original button sizing).
- [ ] On mobile (or with throttled network in DevTools), tap a result with a non-zero clip start time and confirm playback **always** starts at the clip timestamp, not at 0:00.
- [ ] Tap rapidly between two different results and confirm the latest selection wins (no stale seek snaps the wrong track).
- [ ] Confirm desktop playback (instant metadata) still works without any perceivable extra delay.


Made with [Cursor](https://cursor.com)