### PR TITLE
Jamie Pull Agent: mobile layout, playable clip pills while streaming, thicker player panel

### DIFF
--- a/src/components/jamiePullAgent/JamiePullAgent.tsx
+++ b/src/components/jamiePullAgent/JamiePullAgent.tsx
@@ -1446,20 +1446,16 @@ export const JamiePullAgent: React.FC<JamiePullAgentProps> = ({ onSignUp, onUpgr
                 back model selection. */}
           </div>
         ) : (
-          /* Top padding leaves room for the fixed Reset button
-             (fixed top-3 right-4) so it never overlaps the first
-             message bubble on narrow viewports.
-
-             The parent stays full-width. Per-bubble asymmetry (agent
-             messages anchored left with a large right gutter; user
-             messages anchored right with a large left gutter) is
-             handled inside JamiePullAgentMessage via each bubble's own
-             max-width + justify-start / justify-end. */
-          /* pb-64 (256px) clears the absolutely-positioned bottom island
-             at the worst-case (mini-player + chat input) with extra
-             headroom so the last message can always be scrolled fully
-             above the pill instead of getting clipped behind it. */
-          <div className="px-5 md:pl-36 md:pr-[51px] pt-14 pb-64 space-y-5">
+          <>
+            {/* Top padding clears fixed Reset. Thread gutters: px-2.5 on
+                mobile only; md+ keeps pl-36 / pr-[51px]. Bubble width is in
+                JamiePullAgentMessage. pb-64 when mini-player strip is shown,
+                pb-40 when composer-only. */}
+            <div
+              className={`px-2.5 md:pl-36 md:pr-[51px] pt-14 space-y-5 ${
+                showMiniPlayer ? 'pb-64' : 'pb-40'
+              }`}
+            >
             {messages.map((msg, idx) => {
               let originalQuery: string | undefined;
               if (msg.role === 'assistant') {
@@ -1488,6 +1484,7 @@ export const JamiePullAgent: React.FC<JamiePullAgentProps> = ({ onSignUp, onUpgr
             {/* Viewport slack — dynamic; only exists when anchoring new user msg to top */}
             {slackHeight > 0 && <div style={{ height: slackHeight }} aria-hidden="true" />}
           </div>
+          </>
         )}
       </div>
 
@@ -1508,7 +1505,7 @@ export const JamiePullAgent: React.FC<JamiePullAgentProps> = ({ onSignUp, onUpgr
           the pill. */}
       {(showMiniPlayer || hasMessages) && (
         <div className="absolute bottom-0 inset-x-0 px-3 sm:px-6 pb-3 pointer-events-none z-20">
-          <div className="mx-auto w-full max-w-4xl rounded-3xl border border-white/10 bg-black/85 backdrop-blur-lg overflow-hidden shadow-2xl shadow-black/50 pointer-events-auto">
+          <div className="mx-auto w-full max-w-4xl rounded-3xl border-2 border-white/15 bg-black/85 backdrop-blur-lg overflow-hidden shadow-2xl shadow-black/50 pointer-events-auto">
             {showMiniPlayer && (
               <>
                 {/* Prev/Next clip nav — bg removed; the island provides it */}

--- a/src/components/jamiePullAgent/JamiePullAgentMessage.tsx
+++ b/src/components/jamiePullAgent/JamiePullAgentMessage.tsx
@@ -87,6 +87,11 @@ const INITIAL_RETRY_DELAY_MS = 1000;
 async function fetchClipMeta(pineconeId: string): Promise<ClipMeta | null> {
   return new Promise<ClipMeta | null>(resolve => {
     const run = async () => {
+      const cachedHit = clipMetaCache.get(pineconeId);
+      if (cachedHit) {
+        resolve(cachedHit);
+        return;
+      }
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         try {
           const res = await fetch(
@@ -731,8 +736,15 @@ export const JamiePullAgentMessage: React.FC<JamiePullAgentMessageProps> = ({ me
 
   const handleCardClick = useCallback(
     (pineconeId: string) => {
-      const meta = clipMetaCache.get(pineconeId);
-      if (meta && onPlayClip) onPlayClip(meta);
+      if (!onPlayClip) return;
+      const cached = clipMetaCache.get(pineconeId);
+      if (cached) {
+        onPlayClip(cached);
+        return;
+      }
+      void fetchClipMeta(pineconeId).then((meta) => {
+        if (meta) onPlayClip(meta);
+      });
     },
     [onPlayClip]
   );
@@ -761,9 +773,11 @@ export const JamiePullAgentMessage: React.FC<JamiePullAgentMessageProps> = ({ me
     // Agent bubble anchored to the left via justify-start. Capped at 70%
     // on desktop so the bubble is bounded and the right side gets a
     // generous gutter — symmetric (mirrored) with the user bubble's left
-    // gutter. Mobile keeps 90% so prose has room on narrow screens.
+    // gutter. Mobile uses full width of the padded thread so horizontal
+    // gutters come only from the parent (narrow px-2.5) instead of max-w-[90%]
+    // widening the inset on only one side.
     <div className="flex justify-start">
-      <div className="max-w-[90%] md:max-w-[70%] w-full space-y-3">
+      <div className="w-full md:max-w-[70%] space-y-3">
         {(statusMessages.length > 0 || toolCalls.length > 0) && (
           <ActivityTimeline
             statusMessages={statusMessages}


### PR DESCRIPTION
## Summary
Improvements to the Jamie Pull Agent thread and bottom player island.

### Mobile thread
- Tighten horizontal padding below `md` (`px-2.5` instead of `px-5`); desktop unchanged (`md:pl-36` / `md:pr-[51px]`).
- Assistant messages use full thread width on small screens (`w-full md:max-w-[70%]`) so side margins are symmetric instead of `max-w-[90%]` on one column.
- Reduce bottom scroll padding when the mini-player is hidden (`pb-40`), keep generous padding when playing a clip (`pb-64`).

### Correctness
- Fix invalid JSX in the empty/messages ternary by wrapping the conversation branch in a fragment (build was failing).

### Clip UX
- Clip pills now start playback even when hierarchy metadata is not in cache yet (e.g. while the response is still streaming). Clicks trigger `fetchClipMeta` when needed; avoids no-op until stream end.
- Queued `fetchClipMeta` runs resolve immediately if another request filled the cache first.

### Bottom panel
- Slightly thicker border on the floating composer/player island (`border-2 border-white/15`).

Made with [Cursor](https://cursor.com)