### PR TITLE
Add blog sitemap + canonicalize /app/blog URL bar

### DIFF
--- a/api/sitemap.xml.js
+++ b/api/sitemap.xml.js
@@ -1,0 +1,116 @@
+/**
+ * Vercel Serverless Function for /sitemap.xml
+ *
+ * Builds a sitemap that lists static high-value pages plus every blog post
+ * (using the backend-provided canonical URL). Crawlers and LLM agents pick up
+ * /blog/{slug} from here without depending on whatever URL form happens to
+ * leak into share links.
+ */
+
+const fetch = require('node-fetch');
+const { FRONTEND_URL, API_URL } = require('../src/config/urls.js');
+
+const FETCH_TIMEOUT_MS = 6000;
+const PAGE_SIZE = 200;
+const MAX_PAGES = 20;
+
+module.exports = async function handler(req, res) {
+  const frontendUrl = stripTrailingSlash(FRONTEND_URL);
+
+  try {
+    const posts = await fetchAllPosts();
+    const xml = buildSitemap(frontendUrl, posts);
+
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.setHeader('Cache-Control', 'public, s-maxage=600, stale-while-revalidate=3600');
+    return res.status(200).send(xml);
+  } catch (error) {
+    console.error('[Sitemap] Error:', error);
+    res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(200).send(buildSitemap(frontendUrl, []));
+  }
+};
+
+async function fetchAllPosts() {
+  const all = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const url = `${API_URL}/api/blog?page=${page}&limit=${PAGE_SIZE}`;
+    const data = await fetchJson(url);
+    const posts = Array.isArray(data?.posts) ? data.posts : [];
+    all.push(...posts);
+
+    const totalPages = Number(data?.totalPages);
+    if (!Number.isFinite(totalPages) || page >= totalPages) break;
+    if (posts.length < PAGE_SIZE) break;
+  }
+  return all;
+}
+
+async function fetchJson(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`Backend ${res.status} for ${url}`);
+    }
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function buildSitemap(frontendUrl, posts) {
+  const staticEntries = [
+    { loc: `${frontendUrl}/`, changefreq: 'weekly', priority: '1.0' },
+    { loc: `${frontendUrl}/blog`, changefreq: 'daily', priority: '0.9' },
+  ];
+
+  const postEntries = posts
+    .filter(p => p && p.slug)
+    .map(p => {
+      const loc = (p.seo && p.seo.canonical_url) || `${frontendUrl}/blog/${p.slug}`;
+      const lastmodSeconds = p.updated_at || p.created_at;
+      const lastmod = lastmodSeconds
+        ? new Date(lastmodSeconds * 1000).toISOString()
+        : null;
+      return { loc, lastmod, changefreq: 'monthly', priority: '0.8' };
+    });
+
+  const entries = [...staticEntries, ...postEntries];
+
+  const urls = entries.map(entry => {
+    const parts = [
+      `    <loc>${escapeXml(entry.loc)}</loc>`,
+      entry.lastmod ? `    <lastmod>${entry.lastmod}</lastmod>` : null,
+      entry.changefreq ? `    <changefreq>${entry.changefreq}</changefreq>` : null,
+      entry.priority ? `    <priority>${entry.priority}</priority>` : null,
+    ].filter(Boolean).join('\n');
+    return `  <url>\n${parts}\n  </url>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+function stripTrailingSlash(url) {
+  if (typeof url !== 'string') return '';
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function escapeXml(unsafe) {
+  if (typeof unsafe !== 'string') return '';
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://pullthatupjamie.ai/sitemap.xml

--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -210,6 +210,18 @@ const BlogPost: React.FC = () => {
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Canonical path is /blog/:slug. The SSR layer at /blog/:slug bounces humans
+  // into /app/blog/:slug to mount this SPA, which leaves the non-canonical path
+  // in the address bar — and that's what users copy into Slack/iMessage/X. Quietly
+  // rewrite it back to the canonical here, with no reload or React re-render.
+  useEffect(() => {
+    if (!slug || typeof window === 'undefined') return;
+    if (window.location.pathname.startsWith('/app/blog/')) {
+      const canonicalPath = `/blog/${slug}${window.location.search}${window.location.hash}`;
+      window.history.replaceState(null, '', canonicalPath);
+    }
+  }, [slug]);
+
   useEffect(() => {
     if (!slug) return;
     let cancelled = false;

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
       "destination": "/api/blog/[slug]"
     },
     {
+      "source": "/sitemap.xml",
+      "destination": "/api/sitemap.xml"
+    },
+    {
       "source": "/api/rss/:path*",
       "destination": "https://rss-extractor-app-yufbq.ondigitalocean.app/:path*"
     },
@@ -34,6 +38,15 @@
         {
           "key": "Cache-Control",
           "value": "public, s-maxage=600, stale-while-revalidate=120"
+        }
+      ]
+    },
+    {
+      "source": "/api/sitemap.xml",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, s-maxage=600, stale-while-revalidate=3600"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Two cheap fixes to close the SEO/AEO exposure from the recent blog SSR bug report without touching the larger SSR-vs-SPA architecture.

- **Dynamic `/sitemap.xml`** — new Vercel function at `api/sitemap.xml.js` lists every blog post via the backend's `GET /api/blog` endpoint, using the post's `seo.canonical_url` (which points at `/blog/{slug}`) and `updated_at` for `lastmod`. Wired through `vercel.json` and announced in `robots.txt`. Crawlers now discover blog URLs via the canonical path regardless of what people share externally.
- **Canonical URL bar in the SPA** — `BlogPost.tsx` calls `history.replaceState` on mount to rewrite `/app/blog/{slug}` → `/blog/{slug}` whenever the user landed on the SPA path (which is the path the SSR layer JS-redirects humans to). Stops the "user copies URL from address bar → pastes the SPA-only path into Slack/X" leak.

Together these neutralize the SEO/AEO impact of the architectural mismatch flagged in the bug report. The bigger redirect/mirror-SSR question can stay open without ongoing crawler exposure in the meantime.

## Test plan

- [x] `node` invocation of `api/sitemap.xml.js` against the prod backend renders valid XML containing the static landing pages plus all 13 current blog posts (verified locally; both bug-report slugs present with correct `lastmod`).
- [x] `BlogPost.tsx` change is picked up by the running CRA dev server (`history.replaceState(null, '', canonicalPath)` confirmed in `bundle.js`).
- [ ] After deploy, `curl -s https://pullthatupjamie.ai/sitemap.xml` returns XML with all current blog post URLs.
- [ ] After deploy, visiting `/app/blog/{slug}` in a real browser silently leaves the address bar showing `/blog/{slug}` (no reload, no React re-render).
- [ ] Submit the new sitemap URL to Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)