### PR TITLE
Tape: route /api/tape/auth through TAPE_API_URL (was hitting prod)

### DIFF
--- a/src/services/tape/tapeAuth.ts
+++ b/src/services/tape/tapeAuth.ts
@@ -5,7 +5,13 @@
 // persistence). Any /api/tape/* 401 emits an `unauthorized` event; the
 // TapeAuthGate listens and re-shows the password card without a page reload.
 
-import { API_URL } from '../../constants/constants.ts';
+import { TAPE_API_URL } from '../../config/tapeConfig.ts';
+
+// Tape auth must target the Tape-specific backend (alpha / staging / etc.),
+// NOT the app's shared `API_URL`. Otherwise the password POST goes to a
+// host that doesn't serve `/api/tape/*` and 404s. Trailing slash trimmed
+// for safe path concatenation.
+const API_URL = TAPE_API_URL.replace(/\/+$/, '');
 
 const STORAGE_KEY = 'tape.jwt';
 const STORAGE_EXP_KEY = 'tape.jwt.exp';


### PR DESCRIPTION
## Summary

Hotfix for an auth URL bug found right after #122 merged.

`tapeAuth.ts` was the one Tape file still importing the app's shared `API_URL` from `constants/constants.ts`, so the password POST to `/api/tape/auth` landed on the prod host (`pullthatupjamie-nsh57…`) which doesn't serve `/api/tape/*` and 404s on the CORS preflight.

## Fix

Import `TAPE_API_URL` from `config/tapeConfig.ts` instead. Same pattern as the local `API_URL` shadow in `tapeClient.ts` (trailing slash trimmed for safe path concatenation). All Tape URL traffic now uniformly targets the Tape-specific backend.

Audited the rest of `src/services/tape` and `src/components/tape` — only `printLog` remains imported from `constants` (a log helper, no URL involvement). Confirmed clean.

## Test plan

- [x] `npm run build` succeeds
- [ ] Cold-load `/tape` → password gate → submit → JWT stored, lands on launcher (no 404 in network)
- [ ] Auth call in DevTools Network panel hits the alpha host (`pullthatupjamie-explore-alpha-xns9k…`), not prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)