### PR TITLE
Landing redesign + agent-native /for-agents gateway

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,80 @@
+# Product
+
+## Register
+
+brand
+
+> The landing page is the surface in focus. The app itself (`/app/*`) is a product
+> surface; when working there, treat it as `product`.
+
+## Users
+
+Three audiences, in priority order for the landing page:
+
+1. **Researchers & curious humans** (primary). People who want to find what was
+   actually said across podcasts: journalists, analysts, knowledge workers, fans
+   doing a deep dive. Their context is "I have a question and I want the real
+   moment it was discussed, not an AI hallucination." Job to be done: search by
+   meaning, explore connections, collect and share findings.
+2. **Agents & developers** (strong secondary). People (or the machines they send)
+   who want to query Jamie programmatically via the public API, `llms.txt`,
+   OpenAPI spec, and the `/api/pull` orchestration layer. Job to be done: discover
+   that Jamie is agent-native, then either paste a ready prompt into a chat or wire
+   the spec into their own tooling, in one move.
+3. **Podcast creators (Jamie Pro)**. Creators turning back catalogs into clips,
+   social posts, and audience intelligence. Served by `/for-podcasters`.
+
+## Product Purpose
+
+Pull That Up Jamie makes the podcast corpus searchable by meaning, not keywords:
+~109 feeds, ~7K episodes, ~1.9M indexed paragraphs. Ask in natural language, get
+the exact moment with timestamp, audio, and speaker. Results explore as a 3D
+galaxy of connected ideas; findings collect into shareable, AI-analyzable research
+sessions. Crucially, the same corpus is exposed as agent-native infrastructure:
+a public API, `llms.txt`, OpenAPI spec, an `/api/pull` plain-English agent layer,
+and L402 Lightning micropayments. Success for the landing page: a human starts a
+search, or an agent/dev grabs the gateway prompt/spec, without confusion about
+which path is theirs.
+
+## Brand Personality
+
+Three words: **high-signal, confident, builder-credible.**
+
+Voice cuts through noise. The product's own tagline ("More signal. Less slop.") is
+the personality: it has a point of view about the AI-slop era and positions Jamie
+as the antidote, real sources over hallucinated answers. Tone is direct and a
+little opinionated, never hypey. It should feel like a sharp tool made by people
+who use it, not a pitch deck. The fact that it serves both humans and machines is
+a point of pride, stated plainly, not as a gimmick.
+
+## Anti-references
+
+- **Crypto / Lightning-bro.** Despite using L402 payments, never neon-on-black,
+  "web3" hype, rocket emojis, or get-rich energy. The Lightning rail is plumbing,
+  not the pitch.
+- **Corporate / enterprise.** No navy-and-gray sterility, stock photography,
+  soulless "trusted by" logo walls, or vague B2B abstraction.
+- **Generic AI-SaaS reflex.** No gradient blobs, glassmorphism, big-number hero
+  template, or stars-on-a-black-void. (The current cosmic/nebula treatment is
+  exactly this reflex and is being retired.)
+
+## Design Principles
+
+1. **Show the corpus, don't describe it.** Real numbers (1.9M paragraphs, 109
+   feeds) and real interaction beat adjectives. The product proves itself.
+2. **Two doors, one truth.** Humans and agents are both first-class. Make the fork
+   explicit and confident rather than hiding the machine path.
+3. **Signal over atmosphere.** Structure, type, and data carry the page. Decoration
+   earns its place or is cut. This is the visual form of "more signal, less slop."
+4. **Practice what you preach.** A product that filters slop cannot look like slop.
+   Restraint is the brand.
+5. **Respect the visitor's intent.** A researcher wants to search; a dev wants the
+   spec. Reduce the distance from landing to that first real action.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.1 AA. Maintain AA contrast on the dark surface (especially the
+low-opacity white text currently used for body copy, which often fails). Honor
+`prefers-reduced-motion`: the page leans on motion today, so all non-essential
+animation must have a reduced-motion off-ramp. Ensure keyboard focus states and
+real semantic landmarks for the human/agent fork.

--- a/public/index.html
+++ b/public/index.html
@@ -33,10 +33,10 @@
     <meta name="author" content="CASCDR Inc." />
     <meta name="keywords" content="podcast search, semantic search, AI podcast analysis, 3D visualization, podcast clips, podcast transcription, content automation, research sessions, podcast intelligence" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!-- Google Fonts - Inter (app), Newsreader + IBM Plex Mono (Tape skin) -->
+    <!-- Google Fonts - Inter (app), Newsreader + IBM Plex Mono (Tape skin), Schibsted Grotesk + Geist Mono (landing) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=IBM+Plex+Mono:wght@400;500;600&family=Schibsted+Grotesk:wght@400;500;600;700;800;900&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/ForAgentsPage.tsx
+++ b/src/components/ForAgentsPage.tsx
@@ -1,0 +1,285 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Copy, Check, ArrowUpRight, ArrowLeft, Terminal } from 'lucide-react';
+import PageBanner from './PageBanner.tsx';
+import { NavigationMode } from '../constants/constants.ts';
+import { T } from './landingTokens.ts';
+
+// ============================================================
+// /for-agents — the machine door
+// Two jobs, one page:
+//   1. A human pastes one gateway prompt into any chat.
+//   2. A scraper reads real, linked resources and learns exactly
+//      how to use Jamie. The page IS the machine map.
+// ============================================================
+
+const ORIGIN = 'https://www.pullthatupjamie.ai';
+
+const GATEWAY_PROMPT = `Read ${ORIGIN}/llms.txt and the OpenAPI spec it references (${ORIGIN}/api/openapi.json). Jamie is a semantic podcast search API over 343 feeds, 121K episodes, and 24M indexed paragraphs, with a plain-English agent endpoint at POST /api/pull. Use it to help me find, research, and clip what was actually said across podcasts. Start by searching for: `;
+
+const CURL = `curl -N ${ORIGIN}/api/pull \\
+  -H "Content-Type: application/json" \\
+  -H "X-Free-Tier: true" \\
+  -d '{"query": "What are people saying about AI agents?", "stream": true}'`;
+
+interface Resource {
+  name: string;
+  href: string;
+  desc: string;
+  auth?: string;
+}
+
+const RESOURCES: Resource[] = [
+  {
+    name: 'llms.txt',
+    href: `${ORIGIN}/llms.txt`,
+    desc: 'The map. Endpoints, canonical workflows, and auth in one LLM-readable file. Start here.',
+  },
+  {
+    name: 'openapi.json',
+    href: `${ORIGIN}/api/openapi.json`,
+    desc: 'Full machine-readable spec (OpenAPI 3.0): search, discovery, research sessions, clips, transcription.',
+  },
+  {
+    name: '/api/corpus/spec',
+    href: `${ORIGIN}/api/corpus/spec`,
+    desc: 'Human and LLM-readable markdown reference for the corpus-navigation endpoints.',
+  },
+  {
+    name: '/api/corpus/stats',
+    href: `${ORIGIN}/api/corpus/stats`,
+    desc: 'Live corpus-wide counts (feeds, episodes, paragraphs, people, topics). No auth.',
+    auth: 'no auth',
+  },
+  {
+    name: 'ClawHub skill',
+    href: 'https://clawhub.ai/unclejim21/pullthatupjamie',
+    desc: 'Install Jamie as an agent skill: auth flow, search patterns, research-session workflows.',
+  },
+];
+
+// ------------------------------------------------------------
+// Copy-to-clipboard hook + button
+// ------------------------------------------------------------
+function useCopy(): [boolean, (text: string) => void] {
+  const [copied, setCopied] = useState(false);
+  const copy = (text: string) => {
+    navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    }).catch(() => { /* clipboard unavailable; no-op */ });
+  };
+  return [copied, copy];
+}
+
+const CopyButton: React.FC<{ text: string; label?: string }> = ({ text, label = 'Copy' }) => {
+  const [copied, copy] = useCopy();
+  return (
+    <button
+      onClick={() => copy(text)}
+      aria-label={copied ? 'Copied' : label}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '8px',
+        background: copied ? T.accentTint : T.textHi,
+        color: copied ? T.accent : T.surface0,
+        border: copied ? `1px solid ${T.accent}` : 'none',
+        borderRadius: '8px',
+        padding: '10px 16px',
+        fontFamily: T.sans,
+        fontSize: '14px',
+        fontWeight: 600,
+        cursor: 'pointer',
+        whiteSpace: 'nowrap',
+        transition: 'background 0.18s ease, color 0.18s ease, transform 0.18s cubic-bezier(0.16,1,0.3,1)',
+      }}
+      onMouseEnter={(e) => { if (!copied) e.currentTarget.style.transform = 'translateY(-1px)'; }}
+      onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; }}
+    >
+      {copied ? <Check size={15} /> : <Copy size={15} />}
+      {copied ? 'Copied' : label}
+    </button>
+  );
+};
+
+// Small mono step marker, e.g. "01"
+const StepLabel: React.FC<{ n: string; children: React.ReactNode }> = ({ n, children }) => (
+  <div style={{ display: 'flex', alignItems: 'baseline', gap: '14px', marginBottom: '20px' }}>
+    <span style={{ fontFamily: T.mono, fontSize: '13px', color: T.accent, letterSpacing: '0.04em' }}>{n}</span>
+    <h2 style={{ fontFamily: T.sans, fontSize: 'clamp(22px, 3vw, 30px)', fontWeight: 600, color: T.textHi, letterSpacing: '-0.02em', margin: 0 }}>
+      {children}
+    </h2>
+  </div>
+);
+
+// ------------------------------------------------------------
+// Page
+// ------------------------------------------------------------
+const ForAgentsPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div style={{ backgroundColor: T.surface0, minHeight: '100vh', color: T.textHi, position: 'relative', overflowX: 'hidden' }}>
+      <style>
+        {`
+          .fa-wrap { max-width: 880px; margin: 0 auto; padding: 0 clamp(24px, 5vw, 48px); }
+          .fa-section { padding: clamp(40px, 6vw, 72px) 0; border-top: 1px solid ${T.hairlineSoft}; }
+          .fa-resource {
+            display: grid;
+            grid-template-columns: minmax(0, 240px) 1fr auto;
+            gap: clamp(12px, 2.5vw, 32px);
+            align-items: center;
+            padding: 22px 0;
+            border-top: 1px solid ${T.hairlineSoft};
+            text-decoration: none;
+          }
+          .fa-resource:last-child { border-bottom: 1px solid ${T.hairlineSoft}; }
+          .fa-resource:hover .fa-resource-name { color: ${T.accentBright}; }
+          .fa-resource:hover .fa-resource-arrow { transform: translate(2px, -2px); color: ${T.accent}; }
+          @media (max-width: 680px) {
+            .fa-resource { grid-template-columns: 1fr auto; }
+            .fa-resource-desc { display: none; }
+          }
+          @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; } }
+        `}
+      </style>
+
+      <div style={{ position: 'relative', zIndex: 20 }}>
+        <PageBanner logoText="Pull That Up Jamie!" navigationMode={NavigationMode.CLEAN} />
+      </div>
+
+      <main style={{ position: 'relative', zIndex: 1, paddingBottom: '80px' }}>
+        {/* Restrained glow */}
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)',
+            width: '70%', height: '420px',
+            background: `radial-gradient(ellipse at center top, ${T.accentTint} 0%, transparent 70%)`,
+            filter: 'blur(40px)', pointerEvents: 'none', zIndex: 0,
+          }}
+        />
+
+        {/* Intro */}
+        <section className="fa-wrap" style={{ position: 'relative', zIndex: 1, paddingTop: 'clamp(48px, 7vw, 88px)', paddingBottom: 'clamp(16px, 3vw, 32px)' }}>
+          <button
+            onClick={() => navigate('/')}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: '8px',
+              background: 'none', border: 'none', cursor: 'pointer', padding: 0, marginBottom: '32px',
+              fontFamily: T.mono, fontSize: '13px', color: T.textLo, transition: 'color 0.2s ease',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = T.textHi; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = T.textLo; }}
+          >
+            <ArrowLeft size={14} /> back to pullthatupjamie
+          </button>
+
+          <p style={{ fontFamily: T.mono, fontSize: '12px', letterSpacing: '0.12em', textTransform: 'uppercase', color: T.accent, marginBottom: '20px', display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+            <Terminal size={14} /> For agents &amp; developers
+          </p>
+
+          <h1 style={{ fontFamily: T.sans, fontWeight: 800, fontSize: 'clamp(38px, 6.5vw, 68px)', lineHeight: 1.04, letterSpacing: '-0.035em', color: T.textHi, margin: '0 0 22px' }}>
+            Jamie speaks machine.
+          </h1>
+
+          <p style={{ fontFamily: T.sans, fontSize: 'clamp(16px, 1.8vw, 19px)', lineHeight: 1.65, color: T.textMid, maxWidth: '60ch', margin: 0 }}>
+            A public API over <strong style={{ color: T.textHi, fontWeight: 600 }}>343 feeds</strong>, <strong style={{ color: T.textHi, fontWeight: 600 }}>121K episodes</strong>, and <strong style={{ color: T.textHi, fontWeight: 600 }}>24M semantically indexed paragraphs</strong>, with a plain-English orchestration layer at <code style={{ fontFamily: T.mono, fontSize: '0.92em', color: T.accent }}>POST /api/pull</code>. Point an agent at it in one paste, or wire the spec into your own tooling.
+          </p>
+        </section>
+
+        {/* 01 — Gateway prompt */}
+        <section className="fa-wrap fa-section" style={{ position: 'relative', zIndex: 1 }}>
+          <StepLabel n="01">Paste this into any chat</StepLabel>
+          <p style={{ fontFamily: T.sans, fontSize: '15px', color: T.textMid, lineHeight: 1.6, marginTop: 0, marginBottom: '20px', maxWidth: '62ch' }}>
+            Drop this into Claude, ChatGPT, or any agent. It points the model at Jamie's map and spec, then hands it the keys. Add your topic to the end.
+          </p>
+          <div style={{ background: T.surfaceInput, border: `1px solid ${T.hairline}`, borderRadius: '14px', overflow: 'hidden' }}>
+            <pre style={{
+              fontFamily: T.mono, fontSize: '14px', lineHeight: 1.7, color: T.textMid,
+              padding: 'clamp(18px, 3vw, 26px)', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+            }}>
+              {GATEWAY_PROMPT}<span style={{ color: T.accent }}>[your topic]</span>
+            </pre>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '12px 16px', borderTop: `1px solid ${T.hairlineSoft}` }}>
+              <CopyButton text={GATEWAY_PROMPT} label="Copy prompt" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 — Resources */}
+        <section className="fa-wrap fa-section" style={{ position: 'relative', zIndex: 1 }}>
+          <StepLabel n="02">Or read the spec directly</StepLabel>
+          <p style={{ fontFamily: T.sans, fontSize: '15px', color: T.textMid, lineHeight: 1.6, marginTop: 0, marginBottom: '12px', maxWidth: '62ch' }}>
+            Every resource below is a real, crawlable URL. A scraper can follow them and learn the full API surface without a human in the loop.
+          </p>
+          <div role="list">
+            {RESOURCES.map((r) => (
+              <a key={r.name} className="fa-resource" role="listitem" href={r.href} target="_blank" rel="noopener noreferrer">
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '10px', minWidth: 0 }}>
+                  <span className="fa-resource-name" style={{ fontFamily: T.mono, fontSize: '15px', fontWeight: 500, color: T.textHi, transition: 'color 0.2s ease', wordBreak: 'break-word' }}>
+                    {r.name}
+                  </span>
+                  {r.auth && (
+                    <span style={{ fontFamily: T.mono, fontSize: '10px', letterSpacing: '0.06em', textTransform: 'uppercase', color: T.accent, border: `1px solid ${T.accentTint}`, borderRadius: '4px', padding: '2px 6px', whiteSpace: 'nowrap' }}>
+                      {r.auth}
+                    </span>
+                  )}
+                </span>
+                <span className="fa-resource-desc" style={{ fontFamily: T.sans, fontSize: '14px', color: T.textLo, lineHeight: 1.5 }}>
+                  {r.desc}
+                </span>
+                <ArrowUpRight className="fa-resource-arrow" size={18} style={{ color: T.textLo, transition: 'transform 0.25s cubic-bezier(0.16,1,0.3,1), color 0.2s ease', flexShrink: 0 }} />
+              </a>
+            ))}
+          </div>
+        </section>
+
+        {/* 03 — Call it */}
+        <section className="fa-wrap fa-section" style={{ position: 'relative', zIndex: 1 }}>
+          <StepLabel n="03">Or just call it</StepLabel>
+          <p style={{ fontFamily: T.sans, fontSize: '15px', color: T.textMid, lineHeight: 1.6, marginTop: 0, marginBottom: '20px', maxWidth: '62ch' }}>
+            The orchestration endpoint takes a plain-English task and streams a multi-tool agent response (SSE). The free tier is anonymous, rate-limited by IP.
+          </p>
+          <div style={{ background: T.surfaceInput, border: `1px solid ${T.hairline}`, borderRadius: '14px', overflow: 'hidden' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '12px 16px', borderBottom: `1px solid ${T.hairlineSoft}` }}>
+              <span style={{ width: '8px', height: '8px', borderRadius: '50%', background: T.accent }} />
+              <span style={{ fontFamily: T.mono, fontSize: '12px', color: T.textLo, letterSpacing: '0.04em' }}>POST /api/pull · free tier</span>
+            </div>
+            <pre style={{
+              fontFamily: T.mono, fontSize: '13.5px', lineHeight: 1.7, color: T.textMid,
+              padding: 'clamp(18px, 3vw, 26px)', margin: 0, overflowX: 'auto',
+            }}>
+              {CURL}
+            </pre>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '12px 16px', borderTop: `1px solid ${T.hairlineSoft}` }}>
+              <CopyButton text={CURL} label="Copy curl" />
+            </div>
+          </div>
+
+          <p style={{ fontFamily: T.sans, fontSize: '14px', color: T.textLo, lineHeight: 1.65, marginTop: '24px', maxWidth: '64ch' }}>
+            Need more volume? Hit any paid endpoint unauthenticated to get a 402 with a Lightning invoice, then send{' '}
+            <code style={{ fontFamily: T.mono, fontSize: '0.92em', color: T.textMid }}>Authorization: L402 &lt;macaroon&gt;:&lt;preimage&gt;</code>. One credential works across every paid endpoint. ~500 sats covers 150+ searches.
+          </p>
+        </section>
+
+        {/* Closing */}
+        <section className="fa-wrap" style={{ position: 'relative', zIndex: 1, paddingTop: 'clamp(32px, 5vw, 56px)' }}>
+          <p style={{ fontFamily: T.mono, fontSize: '13px', color: T.textLo, lineHeight: 1.7 }}>
+            Human after all?{' '}
+            <button
+              onClick={() => navigate('/app')}
+              style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontFamily: T.mono, fontSize: '13px', color: T.accent, textDecoration: 'underline', textUnderlineOffset: '3px' }}
+            >
+              Open the app
+            </button>
+            {' '}and explore the galaxy yourself.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default ForAgentsPage;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,1184 +1,605 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowRight, Github, Twitter, Mail } from 'lucide-react';
+import { ArrowRight, ArrowUpRight, Search, Github, Twitter, Mail } from 'lucide-react';
 import PageBanner from './PageBanner.tsx';
 import { NavigationMode } from '../constants/constants.ts';
+import { T } from './landingTokens.ts';
+
+// Corpus facts — proof, not adjectives (PRODUCT.md: "show the corpus").
+const CORPUS = [
+  { value: '343', label: 'feeds' },
+  { value: '121K', label: 'episodes' },
+  { value: '24M', label: 'paragraphs' },
+];
 
 // ============================================================
-// TWINKLING STARS CONFIGURATION
+// GLOBAL ANIMATION + RESPONSIVE STYLES
+// One injected stylesheet for entrance reveals and breakpoints.
+// All non-essential motion is disabled under prefers-reduced-motion.
 // ============================================================
-const STARS_CONFIG = {
-  masterOpacity: 0.8,
-  twinkleSpeed: 3,      // Base seconds for twinkle cycle
-};
+const GlobalStyles: React.FC = () => (
+  <style>
+    {`
+      @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(24px); }
+        to   { opacity: 1; transform: translateY(0); }
+      }
+      .reveal {
+        animation: fadeInUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        opacity: 0;
+      }
+      .reveal-d1 { animation-delay: 0.05s; }
+      .reveal-d2 { animation-delay: 0.18s; }
+      .reveal-d3 { animation-delay: 0.31s; }
+      .reveal-d4 { animation-delay: 0.44s; }
+      .reveal-d5 { animation-delay: 0.57s; }
 
-// ============================================================
-// TWINKLING STARS COMPONENT
-// ============================================================
-const TwinklingStars: React.FC = () => {
-  const { masterOpacity, twinkleSpeed } = STARS_CONFIG;
+      @media (prefers-reduced-motion: reduce) {
+        .reveal { animation: none !important; opacity: 1 !important; transform: none !important; }
+        * { scroll-behavior: auto !important; }
+      }
 
-  // Star positions and properties (x%, y%, size, twinkle delay, twinkle duration)
-  const stars = [
-    { x: 5, y: 8, size: 1.5, delay: 0, duration: 3 },
-    { x: 15, y: 25, size: 1, delay: 1.2, duration: 4 },
-    { x: 28, y: 12, size: 2, delay: 0.5, duration: 2.5 },
-    { x: 42, y: 35, size: 1, delay: 2.1, duration: 3.5 },
-    { x: 55, y: 18, size: 1.5, delay: 0.8, duration: 3 },
-    { x: 68, y: 42, size: 1, delay: 1.5, duration: 4.5 },
-    { x: 82, y: 28, size: 2, delay: 0.3, duration: 2 },
-    { x: 92, y: 55, size: 1, delay: 2.5, duration: 3 },
-    { x: 35, y: 65, size: 1.5, delay: 1.8, duration: 3.5 },
-    { x: 48, y: 78, size: 1, delay: 0.6, duration: 4 },
-    { x: 12, y: 88, size: 1.5, delay: 2.2, duration: 2.5 },
-    { x: 72, y: 72, size: 2, delay: 1.1, duration: 3 },
-    { x: 88, y: 15, size: 1, delay: 0.9, duration: 4 },
-    { x: 22, y: 45, size: 1.5, delay: 1.7, duration: 3.5 },
-    { x: 62, y: 92, size: 1, delay: 2.8, duration: 2.5 },
-    { x: 8, y: 52, size: 2, delay: 0.4, duration: 3 },
-    { x: 95, y: 82, size: 1, delay: 1.3, duration: 4 },
-    { x: 38, y: 5, size: 1.5, delay: 2.0, duration: 3 },
-    { x: 75, y: 58, size: 1, delay: 0.7, duration: 3.5 },
-    { x: 18, y: 72, size: 2, delay: 1.9, duration: 2.5 },
-    // Additional stars for density
-    { x: 3, y: 30, size: 1, delay: 0.2, duration: 4.5 },
-    { x: 50, y: 50, size: 1.5, delay: 1.4, duration: 3 },
-    { x: 85, y: 5, size: 1, delay: 2.3, duration: 3.5 },
-    { x: 60, y: 68, size: 1.5, delay: 0.1, duration: 4 },
-    { x: 25, y: 95, size: 1, delay: 1.6, duration: 2.5 },
-  ];
+      /* Hero */
+      .lp-hero { padding: clamp(48px, 7vw, 96px) clamp(24px, 5vw, 64px); }
+      .lp-hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+        gap: clamp(40px, 5vw, 80px);
+        max-width: 1280px;
+        margin: 0 auto;
+        width: 100%;
+        align-items: center;
+      }
+      .lp-headline { font-size: clamp(44px, 7vw, 80px); }
+      @media (max-width: 920px) {
+        .lp-hero-grid { grid-template-columns: 1fr; gap: 40px; }
+        .lp-artifact { order: 2; max-width: 480px; }
+        .lp-copy { order: 1; }
+      }
 
-  return (
-    <>
-      <style>
-        {`
-          @keyframes twinkle {
-            0%, 100% {
-              opacity: 0.3;
-              transform: scale(1);
-            }
-            50% {
-              opacity: 1;
-              transform: scale(1.2);
-            }
-          }
-        `}
-      </style>
-      <div
-        style={{
-          position: 'fixed',
-          inset: 0,
-          zIndex: 1,
-          pointerEvents: 'none',
-          overflow: 'hidden',
-        }}
-      >
-        {stars.map((star, i) => (
-          <div
-            key={i}
-            style={{
-              position: 'absolute',
-              left: `${star.x}%`,
-              top: `${star.y}%`,
-              width: `${star.size}px`,
-              height: `${star.size}px`,
-              borderRadius: '50%',
-              backgroundColor: 'white',
-              opacity: masterOpacity,
-              animation: `twinkle ${star.duration * twinkleSpeed}s ease-in-out ${star.delay}s infinite`,
-              boxShadow: `0 0 ${star.size * 2}px ${star.size * 0.5}px rgba(255,255,255,0.3)`,
-            }}
-          />
-        ))}
-      </div>
-    </>
-  );
-};
+      /* Search field focus ring */
+      .lp-search-input::placeholder { color: ${T.textLo}; }
+      .lp-search:focus-within {
+        border-color: ${T.accent};
+        box-shadow: 0 0 0 3px ${T.accentTint};
+      }
 
-// ============================================================
-// NEBULA CONFIGURATION — Easy to tweak visibility
-// ============================================================
-const NEBULA_CONFIG = {
-  // Master opacity multiplier (0 = invisible, 1 = full strength)
-  masterOpacity: 1.0,
-  
-  // Individual blob settings
-  blobs: {
-    // Warm amber blob (ties to your accent color)
-    amber: {
-      opacity: 0.40,
-      color: 'rgba(200, 150, 80, 0.6)',
-      size: '65%',           // Size relative to viewport
-      speed: 18,             // Seconds per cycle — faster for more visible movement
-    },
-    // Deep blue/purple blob (cosmic contrast)
-    cosmic: {
-      opacity: 0.45,
-      color: 'rgba(70, 90, 170, 0.5)',
-      size: '75%',
-      speed: 22,
-    },
-    // Subtle white/gray nebula dust
-    dust: {
-      opacity: 0.3,
-      color: 'rgba(255, 255, 255, 0.2)',
-      size: '55%',
-      speed: 28,
-    },
-  },
-};
+      /* Paths band */
+      .lp-paths { max-width: 1100px; margin: 0 auto; }
+      .lp-path-row {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: clamp(16px, 3vw, 40px);
+        align-items: center;
+        padding: clamp(24px, 3vw, 36px) clamp(8px, 2vw, 20px);
+        border-top: 1px solid ${T.hairlineSoft};
+        cursor: pointer;
+        transition: background 0.25s ease, padding-left 0.3s cubic-bezier(0.16,1,0.3,1);
+      }
+      .lp-path-row:last-child { border-bottom: 1px solid ${T.hairlineSoft}; }
+      .lp-path-row:hover { background: oklch(0.97 0.004 80 / 0.025); }
+      @media (min-width: 700px) {
+        .lp-path-row:hover { padding-left: clamp(20px, 3vw, 36px); }
+      }
+      @media (max-width: 640px) {
+        .lp-path-row { grid-template-columns: auto 1fr; }
+        .lp-path-desc { display: none; }
+      }
 
-// ============================================================
-// NEBULA BACKGROUND COMPONENT
-// ============================================================
-const NebulaBackground: React.FC = () => {
-  const { masterOpacity, blobs } = NEBULA_CONFIG;
+      /* Why-Jamie split */
+      .lp-why-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+        gap: clamp(40px, 5vw, 72px);
+        max-width: 1180px;
+        margin: 0 auto;
+        align-items: center;
+      }
+      @media (max-width: 980px) {
+        .lp-why-grid { grid-template-columns: 1fr; gap: 40px; }
+        .lp-why-image { order: 2; max-width: 420px; margin: 0 auto; }
+      }
+    `}
+  </style>
+);
 
-  return (
-    <>
-      <style>
-        {`
-          @keyframes nebula-drift-amber {
-            0% {
-              transform: translate(0%, 0%) scale(1);
-              opacity: ${blobs.amber.opacity * masterOpacity};
-            }
-            25% {
-              transform: translate(20%, 12%) scale(1.18);
-              opacity: ${blobs.amber.opacity * masterOpacity * 0.6};
-            }
-            50% {
-              transform: translate(10%, 25%) scale(0.85);
-              opacity: ${blobs.amber.opacity * masterOpacity * 1.25};
-            }
-            75% {
-              transform: translate(-12%, 15%) scale(1.12);
-              opacity: ${blobs.amber.opacity * masterOpacity * 0.7};
-            }
-            100% {
-              transform: translate(0%, 0%) scale(1);
-              opacity: ${blobs.amber.opacity * masterOpacity};
-            }
-          }
-          
-          @keyframes nebula-drift-cosmic {
-            0% {
-              transform: translate(0%, 0%) scale(1);
-              opacity: ${blobs.cosmic.opacity * masterOpacity};
-            }
-            33% {
-              transform: translate(-20%, 18%) scale(1.25);
-              opacity: ${blobs.cosmic.opacity * masterOpacity * 1.2};
-            }
-            66% {
-              transform: translate(15%, -12%) scale(0.8);
-              opacity: ${blobs.cosmic.opacity * masterOpacity * 0.65};
-            }
-            100% {
-              transform: translate(0%, 0%) scale(1);
-              opacity: ${blobs.cosmic.opacity * masterOpacity};
-            }
-          }
-          
-          @keyframes nebula-drift-dust {
-            0% {
-              transform: translate(0%, 0%) scale(1) rotate(0deg);
-              opacity: ${blobs.dust.opacity * masterOpacity};
-            }
-            50% {
-              transform: translate(12%, -10%) scale(1.15) rotate(5deg);
-              opacity: ${blobs.dust.opacity * masterOpacity * 1.5};
-            }
-            100% {
-              transform: translate(0%, 0%) scale(1) rotate(0deg);
-              opacity: ${blobs.dust.opacity * masterOpacity};
-            }
-          }
-        `}
-      </style>
-      
-      {/* Amber nebula blob - positioned upper left, drifts toward center */}
-      <div
-        style={{
-          position: 'fixed',
-          top: '-20%',
-          left: '-10%',
-          width: blobs.amber.size,
-          height: blobs.amber.size,
-          zIndex: 1,
-          pointerEvents: 'none',
-          background: `radial-gradient(ellipse at center, ${blobs.amber.color} 0%, transparent 70%)`,
-          filter: 'blur(60px)',
-          animation: `nebula-drift-amber ${blobs.amber.speed}s ease-in-out infinite`,
-        }}
-      />
-      
-      {/* Cosmic blue/purple blob - positioned lower right */}
-      <div
-        style={{
-          position: 'fixed',
-          bottom: '-15%',
-          right: '-15%',
-          width: blobs.cosmic.size,
-          height: blobs.cosmic.size,
-          zIndex: 1,
-          pointerEvents: 'none',
-          background: `radial-gradient(ellipse at center, ${blobs.cosmic.color} 0%, transparent 70%)`,
-          filter: 'blur(80px)',
-          animation: `nebula-drift-cosmic ${blobs.cosmic.speed}s ease-in-out infinite`,
-        }}
-      />
-      
-      {/* Dust nebula - positioned center, very subtle */}
-      <div
-        style={{
-          position: 'fixed',
-          top: '20%',
-          right: '10%',
-          width: blobs.dust.size,
-          height: blobs.dust.size,
-          zIndex: 1,
-          pointerEvents: 'none',
-          background: `radial-gradient(ellipse at center, ${blobs.dust.color} 0%, transparent 60%)`,
-          filter: 'blur(100px)',
-          animation: `nebula-drift-dust ${blobs.dust.speed}s ease-in-out infinite`,
-        }}
-      />
-    </>
-  );
-};
-
-interface EntryPoint {
-  title: string;
-  oneLiner: string;
-  body: string[];
-  cta: string;
-  link: string;
-  iconType: 'discover' | 'automate' | 'story';
+// Scroll-reveal hook: returns [ref, isVisible].
+function useReveal<T extends HTMLElement>(threshold = 0.18): [React.RefObject<T>, boolean] {
+  const ref = useRef<T>(null);
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const io = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) { setVisible(true); io.disconnect(); } },
+      { threshold }
+    );
+    io.observe(node);
+    return () => io.disconnect();
+  }, [threshold]);
+  return [ref, visible];
 }
 
 // ============================================================
-// ABSTRACT ICONS — Conceptual, thin stroke, with accent glow
-// Size increased 15-20% for better visual anchoring
+// CORPUS READOUT — live-data feel, real numbers in mono
 // ============================================================
-const accentColor = 'rgba(200, 180, 140, 1)'; // Warm amber accent
-const accentGlow = 'rgba(200, 180, 140, 0.4)';
-
-const DiscoverIcon: React.FC<{ isHovered: boolean }> = ({ isHovered }) => (
-  <svg
-    width="56"
-    height="56"
-    viewBox="0 0 48 48"
-    fill="none"
+const CorpusReadout: React.FC<{ className?: string }> = ({ className }) => (
+  <div
+    className={className}
     style={{
-      opacity: isHovered ? 1 : 0.6,
-      filter: isHovered ? `drop-shadow(0 0 12px ${accentGlow})` : 'none',
-      transition: 'opacity 0.2s ease, filter 0.2s ease',
+      display: 'flex',
+      alignItems: 'baseline',
+      gap: '20px',
+      fontFamily: T.mono,
+      flexWrap: 'wrap',
     }}
   >
-    {/* Constellation / branching nodes */}
-    <circle cx="24" cy="12" r="3" stroke={isHovered ? accentColor : 'white'} strokeWidth="1.5" fill="none" style={{ transition: 'stroke 0.2s ease' }} />
-    <circle cx="12" cy="28" r="3" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="36" cy="28" r="3" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="20" cy="38" r="2" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="32" cy="40" r="2" stroke="white" strokeWidth="1.5" fill="none" />
-    {/* Connecting lines */}
-    <line x1="24" y1="15" x2="14" y2="26" stroke="white" strokeWidth="1" opacity="0.5" />
-    <line x1="24" y1="15" x2="34" y2="26" stroke="white" strokeWidth="1" opacity="0.5" />
-    <line x1="14" y1="30" x2="19" y2="36" stroke="white" strokeWidth="1" opacity="0.5" />
-    <line x1="34" y1="30" x2="31" y2="38" stroke="white" strokeWidth="1" opacity="0.5" />
-  </svg>
-);
-
-const AutomateIcon: React.FC<{ isHovered: boolean }> = ({ isHovered }) => (
-  <svg
-    width="56"
-    height="56"
-    viewBox="0 0 48 48"
-    fill="none"
-    style={{
-      opacity: isHovered ? 1 : 0.6,
-      filter: isHovered ? `drop-shadow(0 0 12px ${accentGlow})` : 'none',
-      transition: 'opacity 0.25s ease, filter 0.25s ease',
-    }}
-  >
-    {/* Loop / interlinked system */}
-    <circle cx="16" cy="16" r="6" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="32" cy="16" r="6" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="24" cy="32" r="6" stroke={isHovered ? accentColor : 'white'} strokeWidth="1.5" fill="none" style={{ transition: 'stroke 0.25s ease' }} />
-    {/* Connecting arcs */}
-    <path d="M22 16 L26 16" stroke="white" strokeWidth="1" opacity="0.5" />
-    <path d="M18 21 L21 28" stroke="white" strokeWidth="1" opacity="0.5" />
-    <path d="M30 21 L27 28" stroke="white" strokeWidth="1" opacity="0.5" />
-    {/* Center dot */}
-    <circle cx="24" cy="20" r="1.5" fill="white" opacity="0.4" />
-  </svg>
-);
-
-const StoryIcon: React.FC<{ isHovered: boolean }> = ({ isHovered }) => (
-  <svg
-    width="56"
-    height="56"
-    viewBox="0 0 48 48"
-    fill="none"
-    style={{
-      opacity: isHovered ? 1 : 0.6,
-      filter: isHovered ? `drop-shadow(0 0 12px ${accentGlow})` : 'none',
-      transition: 'opacity 0.25s ease, filter 0.25s ease',
-    }}
-  >
-    {/* Path / framed cluster */}
-    <rect x="8" y="8" width="32" height="32" rx="4" stroke={isHovered ? accentColor : 'white'} strokeWidth="1.5" fill="none" opacity="0.35" style={{ transition: 'stroke 0.25s ease' }} />
-    {/* Inner path/journey */}
-    <circle cx="16" cy="16" r="2" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="32" cy="24" r="2" stroke="white" strokeWidth="1.5" fill="none" />
-    <circle cx="20" cy="32" r="2" stroke="white" strokeWidth="1.5" fill="none" />
-    {/* Winding path */}
-    <path 
-      d="M18 16 C24 16, 24 24, 30 24" 
-      stroke="white" 
-      strokeWidth="1" 
-      fill="none" 
-      opacity="0.5"
-    />
-    <path 
-      d="M30 26 C26 28, 24 30, 22 32" 
-      stroke="white" 
-      strokeWidth="1" 
-      fill="none" 
-      opacity="0.5"
-    />
-  </svg>
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '8px',
+        fontSize: '12px',
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        color: T.textLo,
+      }}
+    >
+      <span
+        style={{
+          width: '7px',
+          height: '7px',
+          borderRadius: '50%',
+          background: T.accent,
+          boxShadow: `0 0 8px ${T.accent}`,
+        }}
+      />
+      Indexed
+    </span>
+    {CORPUS.map((c) => (
+      <span key={c.label} style={{ display: 'inline-flex', alignItems: 'baseline', gap: '6px' }}>
+        <span style={{ fontSize: '17px', fontWeight: 600, color: T.textHi }}>{c.value}</span>
+        <span style={{ fontSize: '12px', color: T.textLo, letterSpacing: '0.02em' }}>{c.label}</span>
+      </span>
+    ))}
+  </div>
 );
 
 // ============================================================
-// HERO SEGMENT — Grid One
-// Layout: Iframe left, Copy right (headline, subhead, body, CTA)
+// HERO — search-forward, galaxy embed kept prominent
 // ============================================================
 const HeroSegment: React.FC = () => {
   const navigate = useNavigate();
-  const [scrollY, setScrollY] = useState(0);
+  const [query, setQuery] = useState('');
 
-  useEffect(() => {
-    const handleScroll = () => {
-      setScrollY(window.scrollY);
-    };
-
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
-
-  // Parallax values based on scroll
-  const spotlightY = scrollY * 0.3;
-  const spotlightScale = 1 + (scrollY * 0.0003);
-  const spotlightOpacity = Math.max(0.03, 0.08 - (scrollY * 0.0001));
+  const submitSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = query.trim();
+    navigate(q ? `/app?q=${encodeURIComponent(q)}` : '/app');
+  };
 
   return (
-    <>
-      {/* Fade-up animation styles */}
-      <style>
-        {`
-          @keyframes fadeInUp {
-            from {
-              opacity: 0;
-              transform: translateY(30px);
-            }
-            to {
-              opacity: 1;
-              transform: translateY(0);
-            }
-          }
-          
-          .animate-fade-up {
-            animation: fadeInUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-            opacity: 0;
-          }
-          
-          .animate-delay-1 { animation-delay: 0.1s; }
-          .animate-delay-2 { animation-delay: 0.25s; }
-          .animate-delay-3 { animation-delay: 0.4s; }
-          .animate-delay-4 { animation-delay: 0.55s; }
-          .animate-delay-5 { animation-delay: 0.7s; }
-          .animate-delay-6 { animation-delay: 0.85s; }
-        `}
-      </style>
-      <section
-        className="hero-section"
-        style={{
-        minHeight: '80vh',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        position: 'relative',
-        overflow: 'visible',
-      }}
-    >
-      {/* Stage plane — subtle backdrop with parallax */}
+    <section className="lp-hero" style={{ position: 'relative', minHeight: '78vh', display: 'flex', alignItems: 'center' }}>
+      {/* Single restrained glow — replaces the cosmic field */}
       <div
+        aria-hidden
         style={{
           position: 'absolute',
           top: '-10%',
-          left: '-5%',
-          right: '-5%',
-          bottom: '-10%',
-          background: `
-            radial-gradient(ellipse 70% 60% at 35% 50%, 
-              rgba(255,255,255,${spotlightOpacity}) 0%, 
-              rgba(255,255,255,${spotlightOpacity * 0.5}) 30%,
-              rgba(255,255,255,${spotlightOpacity * 0.125}) 60%,
-              transparent 80%
-            )
-          `,
-          transform: `translateY(${spotlightY}px) scale(${spotlightScale})`,
-          transition: 'transform 0.1s ease-out',
+          left: '8%',
+          width: '60%',
+          height: '70%',
+          background: `radial-gradient(ellipse at center, ${T.accentTint} 0%, transparent 70%)`,
+          filter: 'blur(40px)',
           pointerEvents: 'none',
           zIndex: 0,
         }}
       />
 
-      {/* Section divider line */}
-      <div
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: '15%',
-          right: '15%',
-          height: '1px',
-          background: 'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.08) 30%, rgba(255,255,255,0.08) 70%, transparent 100%)',
-          zIndex: 1,
-        }}
-      />
+      <div className="lp-hero-grid" style={{ position: 'relative', zIndex: 1 }}>
+        {/* COPY + SEARCH */}
+        <div className="lp-copy">
+          <CorpusReadout className="reveal reveal-d1" />
 
-      {/* Responsive CSS */}
-      <style>
-        {`
-          .hero-section {
-            padding: 80px 60px;
-          }
-          .hero-content {
-            display: flex;
-            flex-direction: row;
-            gap: 80px;
-            max-width: 1300px;
-            width: 100%;
-            margin: 0 auto;
-            align-items: center;
-            position: relative;
-            z-index: 2;
-          }
-          .hero-artifact {
-            flex: 0 0 auto;
-            width: 500px;
-            position: relative;
-          }
-          .hero-copy {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-          }
-          .hero-headline {
-            font-size: 64px;
-          }
-          .hero-subhead {
-            font-size: 28px;
-          }
-          .hero-body {
-            font-size: 17px;
-          }
-          @media (max-width: 1000px) {
-            .hero-section {
-              padding: 60px 28px;
-            }
-            .hero-content {
-              flex-direction: column;
-              gap: 36px;
-              align-items: center;
-              text-align: center;
-            }
-            .hero-artifact {
-              width: 100%;
-              max-width: 360px;
-              order: 2;
-            }
-            .hero-copy {
-              align-items: center;
-              order: 1;
-            }
-            .hero-headline {
-              font-size: 36px !important;
-            }
-            .hero-subhead {
-              font-size: 20px !important;
-              margin-bottom: 20px !important;
-            }
-            .hero-body {
-              font-size: 15px !important;
-              margin-bottom: 28px !important;
-            }
-            .hero-cta {
-              margin-left: auto;
-              margin-right: auto;
-              align-self: center !important;
-            }
-          }
-        `}
-      </style>
-
-      {/* Main content — Iframe + Copy side by side */}
-      <div className="hero-content">
-        {/* ARTIFACT — Square iframe */}
-        <div className="hero-artifact animate-fade-up animate-delay-2">
-          {/* Glow behind iframe */}
-          <div
+          <h1
+            className="lp-headline reveal reveal-d2"
             style={{
-              position: 'absolute',
-              inset: '-24px',
-              background: 'radial-gradient(ellipse 100% 100% at 50% 50%, rgba(255,255,255,0.05) 0%, transparent 60%)',
-              borderRadius: '20px',
-              pointerEvents: 'none',
+              fontFamily: T.sans,
+              fontWeight: 800,
+              lineHeight: 1.02,
+              letterSpacing: '-0.035em',
+              color: T.textHi,
+              margin: '24px 0 20px',
             }}
-          />
-          
-          {/* Iframe container — square */}
+          >
+            More signal.<br />Less slop.
+          </h1>
+
+          <p
+            className="reveal reveal-d3"
+            style={{
+              fontFamily: T.sans,
+              fontSize: 'clamp(16px, 1.6vw, 19px)',
+              fontWeight: 400,
+              lineHeight: 1.6,
+              color: T.textMid,
+              maxWidth: '34ch',
+              marginBottom: '32px',
+            }}
+          >
+            Search thousands of podcasts by meaning, not keywords. Find the exact
+            moment something was said, hear it, and explore how ideas connect.
+          </p>
+
+          {/* Real search — routes into /app?q= */}
+          <form className="reveal reveal-d4" onSubmit={submitSearch} style={{ marginBottom: '20px' }}>
+            <div
+              className="lp-search"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                background: T.surfaceInput,
+                border: `1px solid ${T.hairline}`,
+                borderRadius: '12px',
+                padding: '6px 6px 6px 16px',
+                maxWidth: '600px',
+                transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+              }}
+            >
+              <Search size={18} style={{ color: T.textLo, flexShrink: 0 }} />
+              <input
+                className="lp-search-input"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder='Ask anything: "Saylor on AI?"'
+                aria-label="Search podcasts by meaning"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  color: T.textHi,
+                  fontFamily: T.sans,
+                  fontSize: '16px',
+                  padding: '10px 0',
+                }}
+              />
+              <button
+                type="submit"
+                aria-label="Search"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  background: T.textHi,
+                  color: T.surface0,
+                  border: 'none',
+                  borderRadius: '8px',
+                  padding: '11px 18px',
+                  fontFamily: T.sans,
+                  fontSize: '15px',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                  transition: 'transform 0.18s cubic-bezier(0.16,1,0.3,1), background 0.18s ease',
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-1px)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; }}
+              >
+                Search
+                <ArrowRight size={16} />
+              </button>
+            </div>
+          </form>
+
+          {/* The machine door */}
+          <a
+            className="reveal reveal-d5"
+            href="/for-agents"
+            onClick={(e) => { e.preventDefault(); navigate('/for-agents'); }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '8px',
+              fontFamily: T.mono,
+              fontSize: '13px',
+              letterSpacing: '0.02em',
+              color: T.accent,
+              textDecoration: 'none',
+              transition: 'color 0.2s ease, gap 0.2s ease',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = T.accentBright; e.currentTarget.style.gap = '12px'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = T.accent; e.currentTarget.style.gap = '8px'; }}
+          >
+            {'>'} Are you an agent?
+            <ArrowUpRight size={14} />
+          </a>
+        </div>
+
+        {/* ARTIFACT — the live galaxy embed (kept prominent) */}
+        <div className="lp-artifact reveal reveal-d3" style={{ position: 'relative', width: '100%' }}>
           <div
             style={{
               aspectRatio: '1 / 1',
-              borderRadius: '12px',
+              borderRadius: '14px',
               overflow: 'hidden',
-              border: '1px solid rgba(255,255,255,0.1)',
-              backgroundColor: '#000000',
-              boxShadow: '0 4px 32px rgba(0,0,0,0.5)',
+              border: `1px solid ${T.hairline}`,
+              background: 'oklch(0.12 0.005 80)',
+              boxShadow: '0 8px 40px oklch(0 0 0 / 0.5)',
               position: 'relative',
             }}
           >
             <iframe
               src={`${window.location.origin}/app?sharedSession=08fc784abd3a&embed=true`}
-              style={{
-                width: '100%',
-                height: '100%',
-                border: 'none',
-              }}
-              title="Jamie — Explore Ideas"
+              style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
+              title="Jamie — a live galaxy of connected podcast moments"
               allow="autoplay"
             />
           </div>
-
-          {/* Instructional microcopy */}
           <p
             style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '14px',
-              color: 'rgba(255,255,255,0.4)',
-              marginTop: '16px',
+              fontFamily: T.mono,
+              fontSize: '12px',
+              color: T.textLo,
+              marginTop: '14px',
               textAlign: 'center',
-              letterSpacing: '0.01em',
+              letterSpacing: '0.04em',
             }}
           >
-            Click any star to explore.
+            ↑ live · click any star to explore
           </p>
-        </div>
-
-        {/* COPY — Headline, subhead, body, CTA stacked */}
-        <div className="hero-copy">
-          {/* Headline — Large and bold */}
-          <h1
-            className="hero-headline animate-fade-up animate-delay-1"
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontWeight: 700,
-              lineHeight: 1.05,
-              color: '#ffffff',
-              marginBottom: '24px',
-              letterSpacing: '-0.03em',
-            }}
-          >
-            More signal. Less slop.
-          </h1>
-
-          {/* Subhead */}
-          <p
-            className="hero-subhead animate-fade-up animate-delay-2"
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontWeight: 500,
-              color: 'rgba(255,255,255,0.7)',
-              marginBottom: '32px',
-              letterSpacing: '-0.01em',
-            }}
-          >
-            Jamie surfaces insights visually from real conversations that matter.
-          </p>
-
-          {/* Body copy */}
-          <p
-            className="hero-body animate-fade-up animate-delay-3"
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontWeight: 400,
-              lineHeight: 1.7,
-              color: 'rgba(255,255,255,0.55)',
-              marginBottom: '40px',
-              maxWidth: '440px',
-            }}
-          >
-            Explore concepts visually. Cut through the deluge of AI slop & content. Gather insights from real conversations. Save for later and share with friends.
-          </p>
-
-          {/* CTA — White filled button, right-aligned */}
-          <button
-            className="hero-cta animate-fade-up animate-delay-4"
-            onClick={() => navigate('/app')}
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '10px',
-              padding: '14px 28px',
-              fontSize: '16px',
-              fontWeight: 600,
-              fontFamily: 'Inter, sans-serif',
-              backgroundColor: '#ffffff',
-              color: '#000000',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              transition: 'all 0.2s ease',
-              width: 'fit-content',
-              letterSpacing: '-0.01em',
-              alignSelf: 'flex-end',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.9)';
-              e.currentTarget.style.transform = 'translateY(-1px)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = '#ffffff';
-              e.currentTarget.style.transform = 'translateY(0)';
-            }}
-          >
-            Explore Podcast App
-            <ArrowRight size={18} />
-          </button>
         </div>
       </div>
     </section>
-    </>
   );
 };
 
 // ============================================================
-// ENTRY POINTS SECTION — Section Two
-// Three doors the user can step through. Not a feature grid.
-// Each card is an entry point — inviting, confident, explorable.
+// PATHS — the human/agent fork, as a hairline-separated band
+// (deliberately not a card grid)
 // ============================================================
+interface PathItem {
+  index: string;
+  title: string;
+  desc: string;
+  cta: string;
+  link: string;
+  machine?: boolean;
+}
 
-// Accent colors for CTAs and hover states
-const ctaAccent = 'rgba(200, 180, 140, 1)'; // Warm amber
-const ctaAccentMuted = 'rgba(200, 180, 140, 0.7)';
-const ctaAccentBright = 'rgba(220, 200, 160, 1)';
+const PATHS: PathItem[] = [
+  {
+    index: '01',
+    title: 'Explore conversations',
+    desc: 'Search by meaning, then navigate a 3D galaxy of connected ideas across feeds, speakers, and themes.',
+    cta: 'Open the app',
+    link: '/app',
+  },
+  {
+    index: '02',
+    title: 'Creator tools',
+    desc: 'Turn a back catalog into clips, captions, and audience intelligence. Find your best moments automatically.',
+    cta: 'For podcasters',
+    link: '/for-podcasters',
+  },
+  {
+    index: '03',
+    title: 'Are you an agent?',
+    desc: 'A public API, llms.txt, OpenAPI spec, and a plain-English orchestration layer. Built to be queried by machines.',
+    cta: 'Machine map',
+    link: '/for-agents',
+    machine: true,
+  },
+];
 
-const EntryPointCard: React.FC<{ entry: EntryPoint; isPrimary?: boolean; index?: number }> = ({ entry, isPrimary = false, index = 0 }) => {
+const PathRow: React.FC<{ item: PathItem }> = ({ item }) => {
   const navigate = useNavigate();
-  const [isHovered, setIsHovered] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
-  const cardRef = React.useRef<HTMLDivElement>(null);
-
-  // Intersection Observer for scroll-triggered animation
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          // Add a staggered delay based on index
-          setTimeout(() => setIsVisible(true), index * 150);
-        }
-      },
-      { threshold: 0.2 }
-    );
-
-    if (cardRef.current) {
-      observer.observe(cardRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, [index]);
-
-  // Render the appropriate icon based on type
-  const renderIcon = () => {
-    switch (entry.iconType) {
-      case 'discover':
-        return <DiscoverIcon isHovered={isHovered} />;
-      case 'automate':
-        return <AutomateIcon isHovered={isHovered} />;
-      case 'story':
-        return <StoryIcon isHovered={isHovered} />;
-    }
-  };
-
-  // Micro-asymmetry: Discover card has faster/stronger response
-  const transitionSpeed = isPrimary ? '0.2s' : '0.3s';
-  const hoverLift = isPrimary ? '-5px' : '-4px';
-  const restLift = isPrimary ? '-1px' : '0';
+  const [hover, setHover] = useState(false);
+  const font = item.machine ? T.mono : T.sans;
 
   return (
     <div
-      ref={cardRef}
-      className="entry-point-card"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      onClick={() => navigate(entry.link)}
-      style={{
-        flex: 1,
-        minWidth: '280px',
-        maxWidth: '380px',
-        padding: '40px 32px',
-        cursor: 'pointer',
-        position: 'relative',
-        opacity: isVisible ? 1 : 0,
-        transform: isVisible 
-          ? (isHovered ? `translateY(${hoverLift})` : `translateY(${restLift})`) 
-          : 'translateY(30px)',
-        transition: isVisible 
-          ? `all ${transitionSpeed} ease` 
-          : 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), transform 0.8s cubic-bezier(0.16, 1, 0.3, 1)',
-        boxShadow: isHovered 
-          ? `0 16px 48px rgba(0,0,0,0.35), inset 0 0 40px rgba(200,180,140,0.03)` 
-          : isPrimary ? '0 2px 8px rgba(0,0,0,0.1)' : 'none',
-        borderRadius: '16px',
-        background: isHovered 
-          ? 'rgba(255,255,255,0.025)' 
-          : 'transparent',
-        // Border as doorway threshold — hint of accent on hover
-        border: isHovered 
-          ? '1px solid rgba(200,180,140,0.25)' 
-          : `1px solid rgba(255,255,255,${isPrimary ? '0.12' : '0.10'})`,
-      }}
+      className="lp-path-row"
+      role="link"
+      tabIndex={0}
+      onClick={() => navigate(item.link)}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate(item.link); }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
     >
-      {/* Icon — centered, larger, anchors the card */}
-      <div
+      <span
         style={{
-          marginBottom: '24px',
-          height: '56px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
+          fontFamily: T.mono,
+          fontSize: '13px',
+          color: item.machine ? T.accent : T.textLo,
+          letterSpacing: '0.04em',
         }}
       >
-        {renderIcon()}
-      </div>
+        {item.index}
+      </span>
 
-      {/* Title */}
-      <h3
-        style={{
-          fontFamily: 'Inter, sans-serif',
-          fontSize: '24px',
-          fontWeight: 600,
-          color: '#ffffff',
-          marginBottom: '12px',
-          letterSpacing: '-0.02em',
-          textAlign: 'center',
-        }}
-      >
-        {entry.title}
-      </h3>
-
-      {/* One-liner */}
-      <p
-        style={{
-          fontFamily: 'Inter, sans-serif',
-          fontSize: '15px',
-          fontWeight: 500,
-          color: 'rgba(255,255,255,0.6)',
-          marginBottom: '16px',
-          lineHeight: 1.5,
-          textAlign: 'center',
-        }}
-      >
-        {entry.oneLiner}
-      </p>
-
-      {/* Body copy */}
-      <div style={{ marginBottom: '28px', textAlign: 'center' }}>
-        {entry.body.map((line, idx) => (
-          <p
-            key={idx}
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '14px',
-              fontWeight: 400,
-              color: 'rgba(255,255,255,0.4)',
-              lineHeight: 1.7,
-              marginBottom: idx < entry.body.length - 1 ? '6px' : '0',
-            }}
-          >
-            {line}
-          </p>
-        ))}
-      </div>
-
-      {/* CTA — accent color, arrow on hover only */}
-      <div style={{ textAlign: 'center' }}>
-        <span
+      <div>
+        <h3
           style={{
-            fontFamily: 'Inter, sans-serif',
-            fontSize: '14px',
-            fontWeight: 600,
-            color: isHovered ? ctaAccentBright : ctaAccentMuted,
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: '6px',
-            transition: `color ${transitionSpeed} ease`,
-            letterSpacing: '0.01em',
+            fontFamily: font,
+            fontSize: 'clamp(20px, 2.6vw, 28px)',
+            fontWeight: item.machine ? 500 : 600,
+            color: hover ? (item.machine ? T.accentBright : T.textHi) : T.textHi,
+            letterSpacing: item.machine ? '-0.01em' : '-0.02em',
+            marginBottom: '6px',
+            transition: 'color 0.2s ease',
           }}
         >
-          {entry.cta}
-          <ArrowRight 
-            size={14} 
-            style={{
-              opacity: isHovered ? 1 : 0,
-              transform: isHovered ? 'translateX(2px)' : 'translateX(-4px)',
-              transition: `opacity ${transitionSpeed} ease, transform ${transitionSpeed} ease`,
-              color: ctaAccentBright,
-            }}
-          />
-        </span>
+          {item.title}
+        </h3>
+        <p
+          className="lp-path-desc"
+          style={{
+            fontFamily: T.sans,
+            fontSize: '15px',
+            lineHeight: 1.55,
+            color: T.textMid,
+            maxWidth: '62ch',
+          }}
+        >
+          {item.desc}
+        </p>
       </div>
+
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '8px',
+          fontFamily: item.machine ? T.mono : T.sans,
+          fontSize: '14px',
+          fontWeight: 600,
+          color: item.machine ? T.accent : (hover ? T.textHi : T.textMid),
+          whiteSpace: 'nowrap',
+          transition: 'color 0.2s ease',
+        }}
+      >
+        {item.cta}
+        <ArrowRight
+          size={16}
+          style={{
+            transform: hover ? 'translateX(3px)' : 'translateX(0)',
+            transition: 'transform 0.25s cubic-bezier(0.16,1,0.3,1)',
+          }}
+        />
+      </span>
     </div>
   );
 };
 
-const EntryPointsSection: React.FC = () => {
-  const entryPoints: EntryPoint[] = [
-    {
-      title: 'Discover',
-      oneLiner: 'Find the moments that matter — without knowing what to search for.',
-      body: [
-        'Jamie lets you explore podcasts by meaning, not timestamps.',
-        'Jump between ideas, speakers, and themes the way conversations actually unfold.',
-      ],
-      cta: 'Explore conversations',
-      link: '/app',
-      iconType: 'discover',
-    },
-    {
-      title: 'Automate',
-      oneLiner: 'Turn long conversations into living assets.',
-      body: [
-        'Jamie helps creators find, clip, share, and reuse their best moments — automatically or on demand.',
-        'Less busywork. More signal.',
-      ],
-      cta: 'See creator tools',
-      link: '/for-podcasters',
-      iconType: 'automate',
-    },
-    // {
-    //   title: 'Tell Your Story',
-    //   oneLiner: 'Make complex ideas explorable.',
-    //   body: [
-    //     'From books to research to archives, Jamie turns dense material into interactive maps people can actually navigate.',
-    //     'Built for sense-making, not skimming.',
-    //   ],
-    //   cta: 'Explore custom solutions',
-    //   link: '/for-podcasters',
-    //   iconType: 'story',
-    // },
-  ];
-
+const PathsSection: React.FC = () => {
+  const [ref, visible] = useReveal<HTMLElement>();
   return (
     <section
+      ref={ref}
       style={{
-        minHeight: '70vh',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        padding: '80px 40px',
+        padding: 'clamp(64px, 9vw, 120px) clamp(24px, 5vw, 64px)',
         position: 'relative',
-        overflow: 'hidden',
       }}
     >
-      {/* Subtle ambient glow */}
-      <div
-        style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          width: '120%',
-          height: '100%',
-          background: 'radial-gradient(ellipse 60% 50% at 50% 50%, rgba(255,255,255,0.03) 0%, transparent 60%)',
-          pointerEvents: 'none',
-          zIndex: 0,
-        }}
-      />
-
-      {/* Section divider line */}
-      <div
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: '15%',
-          right: '15%',
-          height: '1px',
-          background: 'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.06) 30%, rgba(255,255,255,0.06) 70%, transparent 100%)',
-          zIndex: 1,
-        }}
-      />
-
-      {/* CSS for responsive grid */}
-      <style>
-        {`
-          .entry-points-grid {
-            display: flex;
-            justify-content: center;
-            gap: 24px;
-            max-width: 1300px;
-            margin: 0 auto;
-            position: relative;
-            z-index: 1;
-          }
-          @media (max-width: 960px) {
-            .entry-points-grid {
-              flex-direction: column;
-              align-items: center;
-              gap: 32px;
-            }
-            .entry-point-card {
-              max-width: 500px !important;
-              width: 100%;
-            }
-          }
-        `}
-      </style>
-
-      {/* Entry Points Grid */}
-      <div className="entry-points-grid">
-        {entryPoints.map((entry, i) => (
-          <EntryPointCard key={i} entry={entry} isPrimary={i === 0} index={i} />
-        ))}
+      <div className="lp-paths">
+        <p
+          style={{
+            fontFamily: T.mono,
+            fontSize: '12px',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: T.textLo,
+            marginBottom: '28px',
+            opacity: visible ? 1 : 0,
+            transform: visible ? 'translateY(0)' : 'translateY(16px)',
+            transition: 'opacity 0.7s cubic-bezier(0.16,1,0.3,1), transform 0.7s cubic-bezier(0.16,1,0.3,1)',
+          }}
+        >
+          Where to start
+        </p>
+        <div
+          style={{
+            opacity: visible ? 1 : 0,
+            transform: visible ? 'translateY(0)' : 'translateY(20px)',
+            transition: 'opacity 0.8s cubic-bezier(0.16,1,0.3,1) 0.1s, transform 0.8s cubic-bezier(0.16,1,0.3,1) 0.1s',
+          }}
+        >
+          {PATHS.map((p) => <PathRow key={p.index} item={p} />)}
+        </div>
       </div>
     </section>
   );
 };
 
 // ============================================================
-// WHY JAMIE EXISTS — Section Three
-// Story-driven section with illustration
+// WHY JAMIE EXISTS — story, re-skinned, accessible contrast
 // ============================================================
 const WhyJamieExistsSection: React.FC = () => {
-  const [isVisible, setIsVisible] = useState(false);
-  const sectionRef = React.useRef<HTMLElement>(null);
+  const [ref, visible] = useReveal<HTMLElement>(0.15);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.15 }
-    );
+  const reveal = (delay: number): React.CSSProperties => ({
+    opacity: visible ? 1 : 0,
+    transform: visible ? 'translateY(0)' : 'translateY(24px)',
+    transition: `opacity 0.8s cubic-bezier(0.16,1,0.3,1) ${delay}s, transform 0.8s cubic-bezier(0.16,1,0.3,1) ${delay}s`,
+  });
 
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
+  const body: React.CSSProperties = {
+    fontFamily: T.sans,
+    fontSize: '17px',
+    lineHeight: 1.75,
+    color: T.textMid,
+    marginBottom: '20px',
+    maxWidth: '64ch',
+  };
 
   return (
     <section
-      ref={sectionRef}
-      className="why-jamie-section"
+      ref={ref}
       style={{
-        minHeight: '80vh',
-        display: 'flex',
-        alignItems: 'center',
-        padding: '100px 60px',
+        padding: 'clamp(72px, 10vw, 130px) clamp(24px, 5vw, 64px)',
+        borderTop: `1px solid ${T.hairlineSoft}`,
         position: 'relative',
-        overflow: 'hidden',
       }}
     >
-      {/* Responsive CSS */}
-      <style>
-        {`
-          .why-jamie-content {
-            display: flex;
-            flex-direction: row;
-            gap: 60px;
-            max-width: 1300px;
-            width: 100%;
-            margin: 0 auto;
-            align-items: center;
-            position: relative;
-            z-index: 2;
-          }
-          .why-jamie-text {
-            flex: 1;
-          }
-          .why-jamie-image {
-            flex: 0 0 380px;
-            position: relative;
-          }
-          @media (max-width: 1100px) {
-            .why-jamie-content {
-              flex-direction: column;
-              gap: 48px;
-              text-align: center;
-            }
-            .why-jamie-text {
-              max-width: 100%;
-              order: 1;
-            }
-            .why-jamie-image {
-              flex: 0 0 auto;
-              width: 100%;
-              max-width: 360px;
-              order: 2;
-            }
-          }
-          @media (max-width: 600px) {
-            .why-jamie-section {
-              padding: 60px 28px !important;
-            }
-            .why-jamie-title {
-              font-size: 32px !important;
-            }
-          }
-        `}
-      </style>
-
-      {/* Content */}
-      <div className="why-jamie-content">
-        {/* Text column */}
-        <div className="why-jamie-text">
+      <div className="lp-why-grid">
+        <div>
           <h2
-            className="why-jamie-title"
             style={{
-              fontFamily: 'Inter, sans-serif',
-              fontWeight: 600,
-              fontSize: '42px',
-              color: '#ffffff',
-              marginBottom: '32px',
-              letterSpacing: '-0.02em',
-              lineHeight: 1.15,
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1), transform 0.8s cubic-bezier(0.16, 1, 0.3, 1)',
+              fontFamily: T.sans,
+              fontWeight: 700,
+              fontSize: 'clamp(30px, 4.4vw, 46px)',
+              color: T.textHi,
+              marginBottom: '28px',
+              letterSpacing: '-0.025em',
+              lineHeight: 1.1,
+              ...reveal(0),
             }}
           >
-            Why Jamie Exists
+            Why Jamie exists
           </h2>
 
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '19px',
-              lineHeight: 1.8,
-              color: 'rgba(255,255,255,0.85)',
-              marginBottom: '20px',
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.1s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.1s',
-            }}
-          >
-            We don't have an information problem.
-            <br />
+          <p style={{ ...body, fontSize: '20px', color: T.textHi, fontWeight: 500, ...reveal(0.1) }}>
+            We don't have an information problem.<br />
             We have a sense-making problem.
           </p>
 
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '17px',
-              lineHeight: 1.8,
-              color: 'rgba(255,255,255,0.6)',
-              marginBottom: '20px',
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.2s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.2s',
-            }}
-          >
-            AI has flooded the world with answers, many of them wrong, shallow, or disconnected from reality. Prompting has replaced understanding. Context gets flattened. Meaning gets lost.
+          <p style={{ ...body, ...reveal(0.2) }}>
+            AI has flooded the world with answers, many of them wrong, shallow, or
+            disconnected from reality. Prompting has replaced understanding. Context
+            gets flattened. Meaning gets lost.
           </p>
 
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '17px',
-              lineHeight: 1.8,
-              color: 'rgba(255,255,255,0.6)',
-              marginBottom: '20px',
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.3s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.3s',
-            }}
-          >
-            Meanwhile, the most valuable ideas still live in real sources: authentic conversations, podcasts, internal knowledge, research, and long-form thinking.
+          <p style={{ ...body, ...reveal(0.3) }}>
+            Meanwhile, the most valuable ideas still live in real sources: authentic
+            conversations, podcasts, internal knowledge, research, and long-form
+            thinking. <span style={{ color: T.textHi, fontWeight: 500 }}>The problem is the tools.</span>
           </p>
 
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '17px',
-              lineHeight: 1.8,
-              color: 'rgba(255,255,255,0.75)',
-              marginBottom: '20px',
-              fontWeight: 500,
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.4s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.4s',
-            }}
-          >
-            The problem is the tools.
+          <p style={{ ...body, ...reveal(0.4) }}>
+            Jamie turns real information into something you can navigate, not just
+            query. It takes genuine data, from podcasts to documentation to archives,
+            and makes it intelligible, explorable, and connected.
           </p>
 
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '17px',
-              lineHeight: 1.8,
-              color: 'rgba(255,255,255,0.6)',
-              marginBottom: '20px',
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.5s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.5s',
-            }}
-          >
-            Jamie was built to turn real information into something you can navigate, not just query. It takes genuine data, from podcasts to process documentation to archives, and makes it intelligible, explorable, and connected.
-          </p>
-
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '18px',
-              lineHeight: 1.8,
-              color: 'rgba(255,255,255,0.85)',
-              opacity: isVisible ? 1 : 0,
-              transform: isVisible ? 'translateY(0)' : 'translateY(30px)',
-              transition: 'opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.6s, transform 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.6s',
-            }}
-          >
-            So humans can actually think again. Debate ideas. Grow. Learn. And become everything they were meant to be.
+          <p style={{ ...body, color: T.textHi, marginBottom: 0, ...reveal(0.5) }}>
+            So humans can actually think again. Debate ideas. Grow. Learn. And become
+            everything they were meant to be.
           </p>
         </div>
 
-        {/* Image column */}
-        <div 
-          className="why-jamie-image"
-          style={{
-            opacity: isVisible ? 1 : 0,
-            transform: isVisible ? 'translateY(0)' : 'translateY(40px)',
-            transition: 'opacity 1s cubic-bezier(0.16, 1, 0.3, 1) 0.3s, transform 1s cubic-bezier(0.16, 1, 0.3, 1) 0.3s',
-          }}
-        >
+        <div className="lp-why-image" style={reveal(0.25)}>
           <img
             src="/why-jamie-hero.png"
-            alt="Scientist exploring a constellation of connected ideas"
+            alt="A researcher tracing connections across a constellation of ideas"
             style={{
               width: '100%',
               height: 'auto',
-              borderRadius: '12px',
-              filter: 'grayscale(100%)',
-              opacity: 0.9,
+              borderRadius: '14px',
+              border: `1px solid ${T.hairlineSoft}`,
+              filter: 'grayscale(35%)',
             }}
           />
         </div>
@@ -1188,166 +609,95 @@ const WhyJamieExistsSection: React.FC = () => {
 };
 
 // ============================================================
-// FOOTER — Links, contact, legal
+// FOOTER — adds a Developers / API column (agent-native truth)
 // ============================================================
+const footerLink: React.CSSProperties = {
+  fontFamily: T.sans,
+  fontSize: '14px',
+  color: T.textMid,
+  textDecoration: 'none',
+  transition: 'color 0.2s ease',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '8px',
+};
+
+const colHead: React.CSSProperties = {
+  fontFamily: T.mono,
+  fontSize: '12px',
+  fontWeight: 500,
+  color: T.textLo,
+  marginBottom: '16px',
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+};
+
+const FooterLink: React.FC<{ href: string; external?: boolean; children: React.ReactNode }> = ({ href, external, children }) => (
+  <a
+    href={href}
+    {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+    style={footerLink}
+    onMouseEnter={(e) => { e.currentTarget.style.color = T.textHi; }}
+    onMouseLeave={(e) => { e.currentTarget.style.color = T.textMid; }}
+  >
+    {children}
+  </a>
+);
+
 const Footer: React.FC = () => {
   const [emailRevealed, setEmailRevealed] = useState(false);
 
   return (
     <footer
       style={{
-        marginTop: '120px',
-        padding: '60px 40px 40px',
-        borderTop: '1px solid rgba(255,255,255,0.08)',
+        marginTop: '40px',
+        padding: 'clamp(48px, 6vw, 72px) clamp(24px, 5vw, 64px) 48px',
+        borderTop: `1px solid ${T.hairline}`,
         position: 'relative',
-        zIndex: 2,
       }}
     >
-      <div
-        style={{
-          maxWidth: '1300px',
-          margin: '0 auto',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '40px',
-        }}
-      >
-        {/* Main footer content */}
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '48px',
-            justifyContent: 'space-between',
-          }}
-        >
+      <div style={{ maxWidth: '1280px', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '48px' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '48px', justifyContent: 'space-between' }}>
           {/* Brand */}
-          <div style={{ minWidth: '200px' }}>
-            <h4
-              style={{
-                fontFamily: 'Inter, sans-serif',
-                fontSize: '18px',
-                fontWeight: 600,
-                color: '#ffffff',
-                marginBottom: '16px',
-              }}
-            >
+          <div style={{ minWidth: '220px', maxWidth: '300px' }}>
+            <h4 style={{ fontFamily: T.sans, fontSize: '18px', fontWeight: 700, color: T.textHi, marginBottom: '14px', letterSpacing: '-0.01em' }}>
               Pull That Up Jamie
             </h4>
-            <p
-              style={{
-                fontFamily: 'Inter, sans-serif',
-                fontSize: '14px',
-                color: 'rgba(255,255,255,0.5)',
-                lineHeight: 1.6,
-                maxWidth: '280px',
-              }}
-            >
-              Filtering out the slop and surfacing the signal.
+            <p style={{ fontFamily: T.sans, fontSize: '14px', color: T.textLo, lineHeight: 1.6 }}>
+              Filtering out the slop and surfacing the signal. For the humans who
+              still want to think, and the agents they send.
             </p>
           </div>
 
+          {/* Developers / API */}
+          <div style={{ minWidth: '170px' }}>
+            <h5 style={colHead}>Developers</h5>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <li><FooterLink href="/for-agents">For agents</FooterLink></li>
+              <li><FooterLink href="/llms.txt" external>llms.txt</FooterLink></li>
+              <li><FooterLink href="https://www.pullthatupjamie.ai/api/openapi.json" external>OpenAPI spec <ArrowUpRight size={13} /></FooterLink></li>
+              <li><FooterLink href="https://clawhub.ai/unclejim21/pullthatupjamie" external>ClawHub skill <ArrowUpRight size={13} /></FooterLink></li>
+            </ul>
+          </div>
+
           {/* Connect */}
-          <div style={{ minWidth: '160px' }}>
-            <h5
-              style={{
-                fontFamily: 'Inter, sans-serif',
-                fontSize: '13px',
-                fontWeight: 600,
-                color: 'rgba(255,255,255,0.7)',
-                marginBottom: '16px',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              Connect
-            </h5>
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              <li style={{ marginBottom: '12px' }}>
-                <a
-                  href="https://github.com/uncleJim21/pullthatupjamie-react"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    fontFamily: 'Inter, sans-serif',
-                    fontSize: '14px',
-                    color: 'rgba(255,255,255,0.55)',
-                    textDecoration: 'none',
-                    transition: 'color 0.2s ease',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                  }}
-                  onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.9)'}
-                  onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}
-                >
-                  <Github size={16} />
-                  GitHub
-                </a>
-              </li>
-              <li style={{ marginBottom: '12px' }}>
-                <a
-                  href="https://x.com/PullThatUpJ_AI"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    fontFamily: 'Inter, sans-serif',
-                    fontSize: '14px',
-                    color: 'rgba(255,255,255,0.55)',
-                    textDecoration: 'none',
-                    transition: 'color 0.2s ease',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                  }}
-                  onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.9)'}
-                  onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}
-                >
-                  <Twitter size={16} />
-                  X / Twitter
-                </a>
-              </li>
+          <div style={{ minWidth: '170px' }}>
+            <h5 style={colHead}>Connect</h5>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <li><FooterLink href="https://github.com/uncleJim21/pullthatupjamie-react" external><Github size={16} />GitHub</FooterLink></li>
+              <li><FooterLink href="https://x.com/PullThatUpJ_AI" external><Twitter size={16} />X / Twitter</FooterLink></li>
               <li>
                 {emailRevealed ? (
-                  <a
-                    href="mailto:jim@cascdr.xyz"
-                    style={{
-                      fontFamily: 'Inter, sans-serif',
-                      fontSize: '14px',
-                      color: 'rgba(200,180,140,0.8)',
-                      textDecoration: 'none',
-                      transition: 'color 0.2s ease',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: '8px',
-                    }}
-                    onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(200,180,140,1)'}
-                    onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(200,180,140,0.8)'}
-                  >
-                    <Mail size={16} />
-                    jim@cascdr.xyz
+                  <a href="mailto:jim@cascdr.xyz" style={{ ...footerLink, color: T.accent }}
+                    onMouseEnter={(e) => { e.currentTarget.style.color = T.accentBright; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.color = T.accent; }}>
+                    <Mail size={16} />jim@cascdr.xyz
                   </a>
                 ) : (
-                  <button
-                    onClick={() => setEmailRevealed(true)}
-                    style={{
-                      fontFamily: 'Inter, sans-serif',
-                      fontSize: '14px',
-                      color: 'rgba(255,255,255,0.55)',
-                      background: 'none',
-                      border: 'none',
-                      padding: 0,
-                      cursor: 'pointer',
-                      transition: 'color 0.2s ease',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: '8px',
-                    }}
-                    onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.9)'}
-                    onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}
-                  >
-                    <Mail size={16} />
-                    Email (click to reveal)
+                  <button onClick={() => setEmailRevealed(true)} style={{ ...footerLink, background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+                    onMouseEnter={(e) => { e.currentTarget.style.color = T.textHi; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.color = T.textMid; }}>
+                    <Mail size={16} />Email (click to reveal)
                   </button>
                 )}
               </li>
@@ -1355,53 +705,11 @@ const Footer: React.FC = () => {
           </div>
 
           {/* Legal */}
-          <div style={{ minWidth: '160px' }}>
-            <h5
-              style={{
-                fontFamily: 'Inter, sans-serif',
-                fontSize: '13px',
-                fontWeight: 600,
-                color: 'rgba(255,255,255,0.7)',
-                marginBottom: '16px',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}
-            >
-              Legal
-            </h5>
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              <li style={{ marginBottom: '12px' }}>
-                <a
-                  href="/privacy"
-                  style={{
-                    fontFamily: 'Inter, sans-serif',
-                    fontSize: '14px',
-                    color: 'rgba(255,255,255,0.55)',
-                    textDecoration: 'none',
-                    transition: 'color 0.2s ease',
-                  }}
-                  onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.9)'}
-                  onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}
-                >
-                  Privacy Policy
-                </a>
-              </li>
-              <li>
-                <a
-                  href="/terms"
-                  style={{
-                    fontFamily: 'Inter, sans-serif',
-                    fontSize: '14px',
-                    color: 'rgba(255,255,255,0.55)',
-                    textDecoration: 'none',
-                    transition: 'color 0.2s ease',
-                  }}
-                  onMouseEnter={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.9)'}
-                  onMouseLeave={(e) => e.currentTarget.style.color = 'rgba(255,255,255,0.55)'}
-                >
-                  Terms of Service
-                </a>
-              </li>
+          <div style={{ minWidth: '150px' }}>
+            <h5 style={colHead}>Legal</h5>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <li><FooterLink href="/privacy">Privacy Policy</FooterLink></li>
+              <li><FooterLink href="/terms">Terms of Service</FooterLink></li>
             </ul>
           </div>
         </div>
@@ -1410,7 +718,7 @@ const Footer: React.FC = () => {
         <div
           style={{
             paddingTop: '24px',
-            borderTop: '1px solid rgba(255,255,255,0.06)',
+            borderTop: `1px solid ${T.hairlineSoft}`,
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
@@ -1418,22 +726,10 @@ const Footer: React.FC = () => {
             gap: '16px',
           }}
         >
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '13px',
-              color: 'rgba(255,255,255,0.4)',
-            }}
-          >
+          <p style={{ fontFamily: T.mono, fontSize: '12px', color: T.textLo }}>
             © {new Date().getFullYear()} Pull That Up Jamie. Open source under GPL-3.0.
           </p>
-          <p
-            style={{
-              fontFamily: 'Inter, sans-serif',
-              fontSize: '13px',
-              color: 'rgba(255,255,255,0.4)',
-            }}
-          >
+          <p style={{ fontFamily: T.mono, fontSize: '12px', color: T.textLo }}>
             Built for sense-making.
           </p>
         </div>
@@ -1442,60 +738,34 @@ const Footer: React.FC = () => {
   );
 };
 
+// ============================================================
+// PAGE
+// ============================================================
 const LandingPage: React.FC = () => {
   return (
     <div
       style={{
-        backgroundColor: '#050505',
+        backgroundColor: T.surface0,
         minHeight: '100vh',
-        color: 'white',
+        color: T.textHi,
         position: 'relative',
         overflowX: 'hidden',
       }}
     >
-      {/* Twinkling stars layer */}
-      <TwinklingStars />
-      
-      {/* Nebula background - breathing cosmic clouds */}
-      <NebulaBackground />
-
-      {/* Full-page gradient overlay for depth */}
-      <div
-        style={{
-          position: 'fixed',
-          inset: 0,
-          background: `
-            radial-gradient(ellipse 80% 50% at 50% 0%, rgba(255,255,255,0.02) 0%, transparent 50%),
-            radial-gradient(ellipse 60% 40% at 100% 100%, rgba(255,255,255,0.015) 0%, transparent 50%),
-            radial-gradient(ellipse 50% 30% at 0% 50%, rgba(255,255,255,0.01) 0%, transparent 50%)
-          `,
-          pointerEvents: 'none',
-          zIndex: 2,
-        }}
-      />
+      <GlobalStyles />
 
       {/* Page Banner */}
       <div style={{ position: 'relative', zIndex: 20 }}>
-        <PageBanner 
-          logoText="Pull That Up Jamie!"
-          navigationMode={NavigationMode.CLEAN}
-        />
+        <PageBanner logoText="Pull That Up Jamie!" navigationMode={NavigationMode.CLEAN} />
       </div>
 
       {/* Content */}
-      <div style={{ position: 'relative', zIndex: 10 }}>
-        {/* Grid One: Hero — Stage + Artifact */}
+      <main style={{ position: 'relative', zIndex: 1 }}>
         <HeroSegment />
-
-        {/* Section Two: Three Entry Points */}
-        <EntryPointsSection />
-
-        {/* Section Three: Why Jamie Exists */}
+        <PathsSection />
         <WhyJamieExistsSection />
-
-        {/* Footer */}
         <Footer />
-      </div>
+      </main>
     </div>
   );
 };

--- a/src/components/landingTokens.ts
+++ b/src/components/landingTokens.ts
@@ -1,0 +1,22 @@
+// ============================================================
+// SHARED LANDING DESIGN TOKENS
+// Restrained strategy: warm-tinted near-black neutrals + a single
+// amber accent (the established identity color, ~rgb(200,180,140)),
+// expressed in OKLCH. Used by the landing page and /for-agents so
+// the two surfaces stay visually in lockstep. See PRODUCT.md.
+// ============================================================
+export const T = {
+  surface0: 'oklch(0.16 0.006 80)',          // page background, warm near-black
+  surface1: 'oklch(0.20 0.007 80)',          // raised panels
+  surfaceInput: 'oklch(0.22 0.008 80)',      // input / interactive fill / code
+  textHi: 'oklch(0.97 0.004 80)',            // headlines, primary
+  textMid: 'oklch(0.82 0.004 80)',           // body
+  textLo: 'oklch(0.68 0.004 80)',            // captions, metadata (AA on surface0)
+  accent: 'oklch(0.83 0.068 78)',            // amber accent
+  accentBright: 'oklch(0.89 0.075 80)',
+  hairline: 'oklch(0.97 0.004 80 / 0.12)',
+  hairlineSoft: 'oklch(0.97 0.004 80 / 0.07)',
+  accentTint: 'oklch(0.83 0.068 78 / 0.10)',
+  sans: "'Schibsted Grotesk', system-ui, -apple-system, sans-serif",
+  mono: "'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace",
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import PodcastFeedPage from './components/podcast/PodcastFeedPage.tsx';
 import DashboardPage from './components/podcast/DashboardPage.tsx';
 import LandingPage from './components/LandingPage.tsx';
 import ForPodcastersPage from './components/ForPodcastersPage.tsx';
+import ForAgentsPage from './components/ForAgentsPage.tsx';
 import PrivacyPage from './components/PrivacyPage.tsx';
 import TermsPage from './components/TermsPage.tsx';
 import TryJamieWizard from './components/TryJamieWizard.tsx';
@@ -131,6 +132,7 @@ const App = () => (
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/for-podcasters" element={<ForPodcastersPage />} />
+      <Route path="/for-agents" element={<ForAgentsPage />} />
       <Route path="/privacy" element={<PrivacyPage />} />
       <Route path="/terms" element={<TermsPage />} />
       <Route path="/app" element={<SearchInterface />} />


### PR DESCRIPTION
## What

Reworks the front page away from the cosmic/stars/nebula treatment toward a **dark-but-disciplined** landing that *shows the corpus instead of describing it*, and adds a new **`/for-agents`** page that serves humans and machines at once.

The driving insight: Jamie is genuinely **agent-native infrastructure** (public API, `llms.txt`, OpenAPI spec, `/api/pull` orchestration, L402). The old design said none of that and leaned on a generic "AI → stars on black" reflex. This makes the human/agent fork explicit and confident.

## Landing page
- **Removed** `TwinklingStars`, `NebulaBackground`, and the scroll-parallax atmosphere.
- **Design tokens** in OKLCH (warm-tinted near-black + a single amber accent, preserving the existing identity color), lifted into a shared `landingTokens.ts`.
- **Type:** Schibsted Grotesk (headlines/UI/body) + Geist Mono (real machine content only), added to `index.html`.
- **Hero:** live corpus readout, a real search field that routes to `/app?q=` (verified it runs the search), the galaxy embed kept prominent, and an "Are you an agent?" door. Stats now reflect `/api/corpus/stats`: **343 feeds · 121K episodes · 24M paragraphs**.
- **Paths:** the identical two-card grid is replaced by a hairline-separated band (the agent row in mono/accent).
- **Why Jamie Exists:** re-skinned, body-text contrast raised to WCAG AA.
- **Footer:** new Developers column (llms.txt, OpenAPI, ClawHub).
- Honors `prefers-reduced-motion`.

## New `/for-agents` page
1. **Copyable gateway prompt** for pasting into any chat (points a model at `llms.txt` + OpenAPI, then hands it a `[your topic]` slot).
2. **Real crawlable links** to `llms.txt`, `openapi.json`, `/api/corpus/spec`, `/api/corpus/stats`, and the ClawHub skill, so a scraper learns the API by reading the page.
3. **Copy-paste `curl`** against `POST /api/pull` (free tier) plus an L402 note.

Wires the `/for-agents` route in `index.js`. Adds `PRODUCT.md` capturing register, audiences, and design principles.

## Notes for review
- Built with the impeccable design skill against a confirmed brief; primary audience is researchers/curious humans, with agents/devs as a strong secondary door.
- Not yet done in a browser pass by the author across every breakpoint; hero verified via screenshot. Copy-button + resource-link click-through on `/for-agents` is worth a manual check.
- Open thread: hero subhead still says "Search thousands of podcasts" which is now conservative vs. 121K episodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)