### PR TITLE
Fix /for-agents mobile margins

### DIFF
--- a/src/components/ForAgentsPage.tsx
+++ b/src/components/ForAgentsPage.tsx
@@ -124,7 +124,7 @@ const ForAgentsPage: React.FC = () => {
       <style>
         {`
           .fa-wrap { max-width: 880px; margin: 0 auto; padding: 0 clamp(24px, 5vw, 48px); }
-          .fa-section { padding: clamp(40px, 6vw, 72px) 0; border-top: 1px solid ${T.hairlineSoft}; }
+          .fa-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); border-top: 1px solid ${T.hairlineSoft}; }
           .fa-resource {
             display: grid;
             grid-template-columns: minmax(0, 240px) 1fr auto;


### PR DESCRIPTION
## Problem
On `/for-agents`, sections **01/02/03** were flush against the viewport edge on mobile while the intro kept its margin, so the page looked misaligned.

## Cause
A CSS shorthand collision in the page's injected styles:

```css
.fa-wrap    { padding: 0 clamp(24px, 5vw, 48px); }  /* horizontal */
.fa-section { padding: clamp(40px, 6vw, 72px) 0; }   /* vertical, but shorthand */
```

Both selectors are single-class (equal specificity), and `.fa-section` comes later in source, so on the step sections (which carry both classes) its `padding` shorthand reset the horizontal padding to `0`.

## Fix
Use longhand `padding-top` / `padding-bottom` in `.fa-section` so `.fa-wrap`'s horizontal padding survives. Sections now align with the intro at every width.

Follow-up to #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)