### PR TITLE
Clip source-language badge for multilingual answers

### DIFF
--- a/src/components/UnifiedSidePanel.tsx
+++ b/src/components/UnifiedSidePanel.tsx
@@ -12,6 +12,7 @@ import { FRONTEND_URL } from '../config/urls.js';
 import { extractImageFromAny } from '../utils/hierarchyImageUtils.ts';
 import { QuotaExceededError } from '../types/errors.ts';
 import QuotaExceededModal, { QuotaExceededData } from './QuotaExceededModal.tsx';
+import { getLanguageBadge, shouldShowLanguageBadge } from '../utils/languageBadge.ts';
 
 export type AnalysisCardJson = {
   pineconeId: string;
@@ -21,6 +22,10 @@ export type AnalysisCardJson = {
    *  an "open in Galaxy" arrow that opens `/app?view=galaxy&q=<quote>` in a
    *  new tab so the user can explore nearest-neighbor clips. */
   quote?: string;
+  /** ISO 639-1 source/audio language of the clip (from the podcast feed
+   *  metadata), e.g. "de". When it differs from the answer language the pill
+   *  renders a "Translated from <language>" badge. Absent → no badge. */
+  language?: string;
 };
 
 type ParsedAnalysisPart =
@@ -226,10 +231,22 @@ export const InlineCardMention: React.FC<{
   onCopyLink?: (pineconeId: string) => void;
   /** When true, renders a white breathing glow to signal this clip is currently playing. */
   isActive?: boolean;
-}> = ({ card, onClick, onCopyLink, isActive }) => {
+  /** ISO 639-1 language the surrounding answer is shown in. When it differs
+   *  from `card.language`, the pill shows a "Translated from <language>" chip. */
+  answerLang?: string;
+}> = ({ card, onClick, onCopyLink, isActive, answerLang }) => {
   const title = card.title || 'Open source';
   const imageUrl = card.episodeImage;
   const [copied, setCopied] = React.useState(false);
+
+  // Source-language badge: only when both languages are known and differ, so a
+  // same-language read or an unlabeled (English-default) feed never mislabels.
+  const showLangBadge = shouldShowLanguageBadge(card.language, answerLang);
+  const clipBadge = showLangBadge ? getLanguageBadge(card.language) : undefined;
+  const answerBadge = showLangBadge ? getLanguageBadge(answerLang) : undefined;
+  const langTooltip = clipBadge
+    ? `Audio is in ${clipBadge.name}; quote shown translated${answerBadge ? ` to ${answerBadge.name}` : ''}.`
+    : undefined;
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -272,6 +289,16 @@ export const InlineCardMention: React.FC<{
         />
       )}
       <span className="text-xs text-gray-200 truncate min-w-0">{title}</span>
+      {clipBadge && (
+        <span
+          className="inline-flex items-center gap-1 flex-shrink-0 ml-0.5 px-1.5 py-0.5 rounded-sm bg-white/[0.06] border border-white/10 text-[10px] text-gray-400 whitespace-nowrap"
+          title={langTooltip}
+          aria-label={langTooltip}
+        >
+          {clipBadge.flag && <span aria-hidden="true">{clipBadge.flag}</span>}
+          <span>Translated from {clipBadge.name}</span>
+        </span>
+      )}
       {card.quote && (
         <a
           href={`${FRONTEND_URL}/app?view=galaxy&q=${encodeURIComponent(card.quote)}`}

--- a/src/components/jamiePullAgent/JamiePullAgentMessage.tsx
+++ b/src/components/jamiePullAgent/JamiePullAgentMessage.tsx
@@ -21,6 +21,7 @@ import { ActivityTimeline, ResponseMetadata } from './JamiePullAgentResultCards.
 import { API_URL } from '../../constants/constants.ts';
 import { InlineCardMention, type AnalysisCardJson } from '../UnifiedSidePanel.tsx';
 import { createClipShareUrl } from '../../utils/urlUtils.ts';
+import { normalizeLang } from '../../utils/languageBadge.ts';
 import TryJamieService from '../../services/tryJamieService.ts';
 
 
@@ -36,6 +37,10 @@ export interface ClipMeta {
   endTime: number;
   text: string;
   publishedDate?: string;
+  /** ISO 639-1 source/audio language from the podcast feed metadata (e.g. "de").
+   *  Drives the "Translated from <language>" badge when it differs from the
+   *  answer language. Undefined when the feed is unlabeled. */
+  language?: string;
 }
 
 const CACHE_STORAGE_KEY = 'workflow_clip_meta_cache';
@@ -102,6 +107,7 @@ async function fetchClipMeta(pineconeId: string): Promise<ClipMeta | null> {
           const h = data.hierarchy;
           const para = h?.paragraph?.metadata;
           const ep = h?.episode?.metadata;
+          const feed = h?.feed?.metadata;
           const meta: ClipMeta = {
             pineconeId,
             episodeTitle: ep?.title || para?.episode || 'Unknown episode',
@@ -112,6 +118,9 @@ async function fetchClipMeta(pineconeId: string): Promise<ClipMeta | null> {
             endTime: para?.end_time ?? 0,
             text: para?.text || '',
             publishedDate: ep?.publishedDate || para?.publishedDate || undefined,
+            // Source/audio language comes from the feed metadata; normalize to a
+            // bare ISO 639-1 code ("de-DE" → "de"). Undefined when unlabeled.
+            language: normalizeLang(feed?.language || para?.language || ep?.language),
           };
           clipMetaCache.set(pineconeId, meta);
           persistCache(clipMetaCache);
@@ -303,7 +312,8 @@ function injectClipCards(
   metaCache: Map<string, ClipMeta>,
   onCardClick: (pineconeId: string) => void,
   onCopyLink: (pineconeId: string) => void,
-  activeClipId?: string
+  activeClipId?: string,
+  answerLang?: string
 ): React.ReactNode {
   const tokenRe = /\[\[CLIP:(\d+)\]\]/g;
 
@@ -326,6 +336,7 @@ function injectClipCards(
           // Transcript text powers the "explore in Galaxy" arrow — opens
           // /app?view=galaxy&q=<quote> so the user can see neighbors.
           quote: meta?.text,
+          language: meta?.language,
         };
         out.push(
           <InlineCardMention
@@ -334,6 +345,7 @@ function injectClipCards(
             onClick={onCardClick}
             onCopyLink={onCopyLink}
             isActive={activeClipId === pineconeId}
+            answerLang={answerLang}
           />
         );
       } else {
@@ -347,7 +359,7 @@ function injectClipCards(
 
   if (Array.isArray(node)) {
     return node.map((child) =>
-      injectClipCards(child, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId)
+      injectClipCards(child, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId, answerLang)
     );
   }
 
@@ -356,7 +368,7 @@ function injectClipCards(
     if (!children) return node;
     return React.cloneElement(node as any, {
       ...(node.props as any),
-      children: injectClipCards(children, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId),
+      children: injectClipCards(children, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId, answerLang),
     });
   }
 
@@ -393,11 +405,12 @@ const MarkdownWithClips: React.FC<{
   onCardClick: (pineconeId: string) => void;
   onCopyLink: (pineconeId: string) => void;
   activeClipId?: string;
-}> = ({ text, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId }) => {
+  answerLang?: string;
+}> = ({ text, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId, answerLang }) => {
   const inject = useCallback(
     (children: React.ReactNode) =>
-      injectClipCards(children, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId),
-    [clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId]
+      injectClipCards(children, clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId, answerLang),
+    [clipsByIndex, metaCache, onCardClick, onCopyLink, activeClipId, answerLang]
   );
 
   const components = useMemo(
@@ -798,6 +811,7 @@ export const JamiePullAgentMessage: React.FC<JamiePullAgentMessageProps> = ({ me
                 onCardClick={handleCardClick}
                 onCopyLink={handleCopyLink}
                 activeClipId={activeClipId}
+                answerLang={donePayload?.responseLanguage}
               />
             </div>
             {message.textPaused && !message.streamComplete && (

--- a/src/types/jamiePullAgent.ts
+++ b/src/types/jamiePullAgent.ts
@@ -77,6 +77,10 @@ export interface AgentTextEvent {
 export interface AgentDoneEvent {
   sessionId: string;
   model: string;
+  /** ISO 639-1 language Jamie answered in (e.g. "en", "de"). Additive field —
+   *  may be absent on older backends. Used to decide whether a clip's audio
+   *  language differs from the answer language (source-language badge). */
+  responseLanguage?: string;
   rounds: number;
   toolCalls: { name: string; resultCount: number; latencyMs: number }[];
   tokens: { input: number; output: number };

--- a/src/utils/languageBadge.ts
+++ b/src/utils/languageBadge.ts
@@ -1,0 +1,78 @@
+// Source-language badge helpers.
+//
+// Jamie answers in the user's language and translates non-English clip quotes
+// into that language. When the displayed quote is (say) English but the audio
+// is German, we show a small "Translated from German" chip on the clip pill so
+// the user isn't surprised to hear a foreign language on play.
+//
+// The badge compares two ISO 639-1 codes:
+//   • clip language    — the audio's language, from the podcast feed metadata
+//   • answer language  — the language Jamie replied in (`responseLanguage`)
+// and shows only when they differ. See the Clip Source-Language Badge spec.
+
+export interface LanguageBadge {
+  /** Best-effort flag emoji. Language ≠ country, so this is the most-associated
+   *  flag, not an authoritative one. May be '' for codes we don't map. */
+  flag: string;
+  /** English display name, e.g. "German". Falls back to the uppercased code. */
+  name: string;
+}
+
+// Codes we expect to see across the indexed feeds. Anything not listed still
+// renders (name = uppercased code, no flag) so a newly-supported feed language
+// degrades gracefully rather than disappearing.
+const LANGUAGE_LABELS: Record<string, LanguageBadge> = {
+  en: { flag: '🇬🇧', name: 'English' },
+  de: { flag: '🇩🇪', name: 'German' },
+  es: { flag: '🇪🇸', name: 'Spanish' },
+  fr: { flag: '🇫🇷', name: 'French' },
+  it: { flag: '🇮🇹', name: 'Italian' },
+  pt: { flag: '🇵🇹', name: 'Portuguese' },
+  nl: { flag: '🇳🇱', name: 'Dutch' },
+  sv: { flag: '🇸🇪', name: 'Swedish' },
+  no: { flag: '🇳🇴', name: 'Norwegian' },
+  da: { flag: '🇩🇰', name: 'Danish' },
+  fi: { flag: '🇫🇮', name: 'Finnish' },
+  pl: { flag: '🇵🇱', name: 'Polish' },
+  ru: { flag: '🇷🇺', name: 'Russian' },
+  uk: { flag: '🇺🇦', name: 'Ukrainian' },
+  cs: { flag: '🇨🇿', name: 'Czech' },
+  tr: { flag: '🇹🇷', name: 'Turkish' },
+  ja: { flag: '🇯🇵', name: 'Japanese' },
+  ko: { flag: '🇰🇷', name: 'Korean' },
+  zh: { flag: '🇨🇳', name: 'Chinese' },
+  hi: { flag: '🇮🇳', name: 'Hindi' },
+  ar: { flag: '🇸🇦', name: 'Arabic' },
+};
+
+/**
+ * Normalize a language tag to a lowercase ISO 639-1 base code: strips region
+ * subtags and whitespace ("en-US" → "en", "DE" → "de"). Returns undefined for
+ * empty/non-string input so callers can treat "no signal" uniformly.
+ */
+export function normalizeLang(code?: string | null): string | undefined {
+  if (!code || typeof code !== 'string') return undefined;
+  const base = code.trim().toLowerCase().split(/[-_]/)[0];
+  return base || undefined;
+}
+
+/** Resolve a language code to its { flag, name } for display. */
+export function getLanguageBadge(code?: string | null): LanguageBadge | undefined {
+  const norm = normalizeLang(code);
+  if (!norm) return undefined;
+  return LANGUAGE_LABELS[norm] || { flag: '', name: norm.toUpperCase() };
+}
+
+/**
+ * Whether a "translated from" badge should be shown for a clip. True only when
+ * both languages are known and they differ — so an unknown/missing signal (the
+ * default "en" feed, a same-language read) never produces a wrong badge.
+ */
+export function shouldShowLanguageBadge(
+  clipLang?: string | null,
+  answerLang?: string | null
+): boolean {
+  const clip = normalizeLang(clipLang);
+  const answer = normalizeLang(answerLang);
+  return !!clip && !!answer && clip !== answer;
+}


### PR DESCRIPTION
## What & why

Jamie now answers in the user's language and translates non-English clip quotes into that language. When the displayed quote is (e.g.) English but the audio is German/Spanish, users were confused — they'd click play and hear a foreign language. This adds a per-clip **source-language signal** so the UI shows a small "Translated from <language>" chip on the clip pill.

Purely additive — no new endpoints, no breaking changes.

## How it works

The badge compares two signals and renders **only when they differ**:

| Signal | Source |
|--------|--------|
| Clip language (audio) | podcast feed metadata — `hierarchy.feed.metadata.language`, normalized to a bare ISO 639-1 code (`de-DE` → `de`) |
| Answer language | `responseLanguage` on the `/api/pull` `done` event |

`shouldShowLanguageBadge()` returns true only when **both** languages are known and they differ, so a same-language read or an unlabeled (English-default) feed never produces a wrong badge — it fails silently rather than mislabeling.

## Changes

- **`src/utils/languageBadge.ts`** (new) — ISO 639-1 → `{ flag, name }` lookup plus `normalizeLang()`, `getLanguageBadge()`, and `shouldShowLanguageBadge()`.
- **`src/types/jamiePullAgent.ts`** — `AgentDoneEvent` gains `responseLanguage` (already captured via the stored done payload; no hook change needed).
- **`src/components/jamiePullAgent/JamiePullAgentMessage.tsx`** — `ClipMeta` gains `language` (sourced from feed metadata); `answerLang` threaded from `donePayload.responseLanguage` down through `MarkdownWithClips` → `injectClipCards` → the pill.
- **`src/components/UnifiedSidePanel.tsx`** — `AnalysisCardJson` gains `language`; `InlineCardMention` renders a subtle, low-emphasis chip near the episode title with a tooltip (_"Audio is in German; quote shown translated to English."_).

## Edge cases handled

- `language === answerLang` → no badge.
- Unlabeled feed (defaults to `en`) read by an English answer → no badge.
- Unknown/new ISO code → still renders (name = uppercased code, flag omitted).
- During streaming, the badge appears once the `done` event lands (when `responseLanguage` arrives) — reassurance, not blocking.

## Backend dependency

This path hydrates clips via `/api/get-hierarchy` and reads `hierarchy.feed.metadata.language`, and reads `responseLanguage` off the `/api/pull` `done` event. Both fields must be populated server-side for the badge to appear. The tape skin has its own separate clip pill and is intentionally untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)